### PR TITLE
Update DB schema to support tax optimization fields and rules

### DIFF
--- a/src/lib/db.test.ts
+++ b/src/lib/db.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from 'vitest';
 import { db } from './db';
-import type { Account, Income, Profile } from './db';
+import type { Account, Income, Profile, TaxYearRule } from './db';
+import { getTaxConstants } from '../constants/taxConstants';
 
 describe('Database Schema', () => {
     beforeEach(async () => {
@@ -15,6 +16,7 @@ describe('Database Schema', () => {
         expect(db.settings).toBeDefined();
         expect(db.monthlyArchives).toBeDefined();
         expect(db.notifications).toBeDefined();
+        expect(db.taxRules).toBeDefined();
     });
 
     it('should support new Account fields', async () => {
@@ -30,7 +32,8 @@ describe('Database Schema', () => {
             updatedAt: Date.now(),
             notes: 'Test note',
             alertText: 'Test alert',
-            alertType: 'warning'
+            alertType: 'warning',
+            taxWrapper: 'Standard'
         };
 
         await db.accounts.add(account);
@@ -40,6 +43,7 @@ describe('Database Schema', () => {
         expect(savedAccount?.institutionName).toBe('Bank A');
         expect(savedAccount?.institutionCode).toBe('B');
         expect(savedAccount?.interestRate).toBe(4.5);
+        expect(savedAccount?.taxWrapper).toBe('Standard');
     });
 
     it('should support new Profile fields', async () => {
@@ -65,7 +69,8 @@ describe('Database Schema', () => {
             name: 'Salary',
             amount: 5000,
             frequency: 'monthly',
-            type: 'salary'
+            type: 'salary',
+            taxCategory: 'Earned'
         };
 
         await db.incomes.add(income);
@@ -73,6 +78,7 @@ describe('Database Schema', () => {
 
         expect(savedIncome).toEqual(income);
         expect(savedIncome?.type).toBe('salary');
+        expect(savedIncome?.taxCategory).toBe('Earned');
     });
 
     it('should support Settings table', async () => {
@@ -88,5 +94,19 @@ describe('Database Schema', () => {
         const savedSettings = await db.settings.get('default');
 
         expect(savedSettings).toEqual(settings);
+    });
+
+    it('should support TaxYearRule table', async () => {
+        const constants = getTaxConstants('2024-2025');
+        const taxRule: TaxYearRule = {
+            id: '2024-2025',
+            ...constants
+        };
+
+        await db.taxRules.add(taxRule);
+        const savedRule = await db.taxRules.get('2024-2025');
+
+        expect(savedRule).toEqual(taxRule);
+        expect(savedRule?.BasicRate).toBe(0.2);
     });
 });

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -1,5 +1,8 @@
 import Dexie, { type EntityTable } from 'dexie';
 
+// Assuming you export this type from your constants file
+import type { TaxYearConstants } from '../constants/taxConstants';
+
 export interface Profile {
     id: string; // usually 'default' but can be a UUID
     name: string;
@@ -14,7 +17,6 @@ export interface Account {
     name: string;
     type: string;
     balance: number;
-    // New fields
     institutionName: string;
     institutionCode: string; // e.g. 'S', 'B', 'H'
     interestRate: number; // Percentage, e.g. 5.25
@@ -22,6 +24,8 @@ export interface Account {
     notes?: string;
     alertText?: string;
     alertType?: 'warning' | 'error' | 'info';
+    // --- New Tax Optimization Field ---
+    taxWrapper: string; // e.g., 'ISA', 'SIPP', 'Premium Bonds', 'Standard'
 }
 
 export interface Income {
@@ -30,8 +34,9 @@ export interface Income {
     name: string;
     amount: number;
     frequency: string;
-    // New fields
-    type: string; // 'salary', 'pension', 'rental', 'dividend', 'other'
+    // --- Updated Tax Optimization Fields ---
+    type: string; // e.g., 'salary', 'rental', 'other'
+    taxCategory: string; // e.g., 'Pension', 'State Pension', 'Dividend', 'Tax-Free', 'Earned'
 }
 
 export interface Scenario {
@@ -43,7 +48,7 @@ export interface Scenario {
 export interface Settings {
     id: string; // 'default'
     currency: string;
-    taxYear: string;
+    taxYear: string; // Acts as the FK pointing to TaxYearRule.id
     icloudSync: boolean;
     lastSynced?: number;
 }
@@ -54,7 +59,7 @@ export interface MonthlyArchive {
     year: number;
     totalInterest: number;
     closedAt: number;
-    data: any; // Snapshot of accounts/incomes
+    data: any; // Snapshot of accounts/incomes and calculated tax results
 }
 
 export interface AppNotification {
@@ -68,6 +73,11 @@ export interface AppNotification {
     actionUrl?: string;
 }
 
+// --- New Table Interface ---
+export interface TaxYearRule extends TaxYearConstants {
+    id: string; // e.g., '2024-2025', '2025-2026'
+}
+
 export const db = new Dexie('IncomeTrackDB') as Dexie & {
     profile: EntityTable<Profile, 'id'>;
     accounts: EntityTable<Account, 'id'>;
@@ -76,6 +86,7 @@ export const db = new Dexie('IncomeTrackDB') as Dexie & {
     settings: EntityTable<Settings, 'id'>;
     monthlyArchives: EntityTable<MonthlyArchive, 'id'>;
     notifications: EntityTable<AppNotification, 'id'>;
+    taxRules: EntityTable<TaxYearRule, 'id'>; // Added to DB instance
 };
 
 // Schema version 1
@@ -95,4 +106,20 @@ db.version(2).stores({
     settings: '&id',
     monthlyArchives: '&id, month, year',
     notifications: '&id, date, read'
+});
+
+// Schema version 3 - Tax Optimization & Rule Engine
+db.version(3).stores({
+    // Inherit everything from v2...
+    profile: '&id',
+    // Added taxWrapper as an index in case you want to query all ISAs quickly
+    accounts: '&id, ownerId, name, type, institutionName, taxWrapper',
+    // Added taxCategory as an index to quickly sum up just pension income
+    incomes: '&id, ownerId, name, frequency, type, taxCategory',
+    scenarios: '&id, name',
+    settings: '&id',
+    monthlyArchives: '&id, month, year',
+    notifications: '&id, date, read',
+    // New table. Just need the primary key indexed.
+    taxRules: '&id'
 });


### PR DESCRIPTION
Updated the Dexie database schema to version 3. This includes adding `taxWrapper` to the `Account` interface and `taxCategory` to the `Income` interface to support tax optimization features. A new table `taxRules` was also added to store tax year rules, using the `TaxYearRule` interface which extends `TaxYearConstants`. Updated unit tests to cover these changes.

---
*PR created automatically by Jules for task [4211688341246074934](https://jules.google.com/task/4211688341246074934) started by @John-Bell*