### PR TITLE
Add estimated accrued interest calculation to monthly archive

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -57,6 +57,7 @@ export interface MonthlyArchive {
     month: string; // "October 2025"
     year: number;
     totalInterest: number;
+    estimatedAccruedInterest: number;
     closedAt: number;
     data: any; // Snapshot of accounts/incomes and calculated tax results
 }
@@ -160,6 +161,19 @@ db.version(5).stores({
 
 // Schema version 6 - Added budgets
 db.version(6).stores({
+    profile: '&id',
+    accounts: '&id, ownerId, name, category, bonusRateActive, bonusEndDate',
+    incomes: '&id, ownerId, name, frequency, type, taxCategory',
+    scenarios: '&id, name',
+    settings: '&id',
+    monthlyArchives: '&id, month, year',
+    notifications: '&id, date, read',
+    taxRules: '&id',
+    budgets: '&id, category, name, paymentSource, ownership'
+});
+
+// Schema version 7 - Added estimatedAccruedInterest to MonthlyArchive
+db.version(7).stores({
     profile: '&id',
     accounts: '&id, ownerId, name, category, bonusRateActive, bonusEndDate',
     incomes: '&id, ownerId, name, frequency, type, taxCategory',

--- a/src/pages/DashboardPage.tsx
+++ b/src/pages/DashboardPage.tsx
@@ -10,6 +10,7 @@ import { useStore } from '@/store/useStore';
 import { useLiveQuery } from 'dexie-react-hooks';
 import { db } from '@/lib/db';
 import { MainHeaderActions } from '../components/layout/MainHeaderActions';
+import { archiveCurrentMonth } from '@/services/archiveService';
 
 export function DashboardPage() {
     const { profile } = useStore();
@@ -145,7 +146,7 @@ export function DashboardPage() {
                     description="Archive your July data now"
                     icon="archive"
                     buttonText="Close Month"
-                    onClick={() => { }}
+                    onClick={() => archiveCurrentMonth()}
                 />
 
                 <div className="mb-2">

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -4,6 +4,7 @@ import { Header } from '../components/layout/Header';
 import { Icon } from '../components/ui/Icon';
 import { MonthlyCloseOut } from '../components/settings/MonthlyCloseOut';
 import { HistoryLogItem } from '../components/settings/HistoryLogItem';
+import { archiveCurrentMonth } from '@/services/archiveService';
 
 export function SettingsPage() {
     return (
@@ -44,7 +45,7 @@ export function SettingsPage() {
                     <MonthlyCloseOut
                         description="Archives current balances and interest rates to history and prepares the ledger for the new month. This action is final."
                         monthString="October 2025"
-                        onArchive={() => { }}
+                        onArchive={() => archiveCurrentMonth()}
                     />
                 </section>
 

--- a/src/services/archiveService.ts
+++ b/src/services/archiveService.ts
@@ -1,0 +1,58 @@
+import { db } from '@/lib/db';
+
+export async function archiveCurrentMonth() {
+    // 1. Determine current month details
+    const now = new Date();
+    // We assume the close out is for the current month being completed
+    const monthString = now.toLocaleString('en-US', { month: 'long', year: 'numeric' });
+    const year = now.getFullYear();
+    const id = `${year}-${String(now.getMonth() + 1).padStart(2, '0')}`;
+
+    // 2. Load accounts
+    const accounts = await db.accounts.toArray();
+
+    // 3. Calculate Interest
+    let totalInterest = 0;
+    let estimatedAccruedInterest = 0;
+
+    const startOfMonth = new Date(year, now.getMonth(), 1).getTime();
+    const endOfMonth = new Date(year, now.getMonth() + 1, 0, 23, 59, 59, 999).getTime();
+    const msInMonth = endOfMonth - startOfMonth;
+
+    accounts.forEach(acc => {
+        if (acc.balance && acc.interestRate) {
+            // Annual interest for this account
+            const annualInterest = acc.balance * (acc.interestRate / 100);
+
+            // Monthly interest (straight line)
+            const monthlyInterest = annualInterest / 12;
+            totalInterest += monthlyInterest;
+
+            // Weighted accrued interest based on updatedAt
+            // Calculate how long the balance was held in the current month up to 'now'
+            const heldFrom = Math.max(startOfMonth, acc.updatedAt || startOfMonth);
+            const heldUntil = Math.min(now.getTime(), endOfMonth);
+
+            const msHeldThisMonth = Math.max(0, heldUntil - heldFrom);
+
+            const fractionOfMonthHeld = msHeldThisMonth / msInMonth;
+            estimatedAccruedInterest += monthlyInterest * fractionOfMonthHeld;
+        }
+    });
+
+    // 4. Construct the payload
+    const dataSnapshot = {
+        accounts,
+    };
+
+    // 5. Save to the db
+    await db.monthlyArchives.put({
+        id,
+        month: monthString,
+        year,
+        totalInterest,
+        estimatedAccruedInterest,
+        closedAt: now.getTime(),
+        data: dataSnapshot
+    });
+}


### PR DESCRIPTION
This PR adds the `estimatedAccruedInterest` field to the `MonthlyArchive` database store and implements the core logic for calculating and archiving this value when a month is closed.

* Adds `estimatedAccruedInterest` to `MonthlyArchive` and bumps database schema version.
* Implements `archiveCurrentMonth()` service to perform the archiving and the weighted time calculation.
* Connects the UI's dummy "Close Month" buttons to actually run the archive logic.

---
*PR created automatically by Jules for task [13520744968964965279](https://jules.google.com/task/13520744968964965279) started by @John-Bell*