### PR TITLE
Constrain Header width to match main layout

### DIFF
--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -17,7 +17,7 @@ export function Header({
     className,
 }: HeaderProps) {
     return (
-        <header className={cn('flex items-center justify-between px-6 py-4', className)}>
+        <header className={cn('w-full max-w-md md:max-w-2xl lg:max-w-4xl mx-auto flex items-center justify-between px-6 py-4', className)}>
             <div className="flex items-center gap-3">
                 {leftElement}
                 <div className="flex flex-col">


### PR DESCRIPTION
Added `w-full max-w-md md:max-w-2xl lg:max-w-4xl mx-auto` to the Header component to constrain its maximum width on larger devices (like iPads and iPhones in landscape) and horizontally align it with the main content container and bottom navigation. This prevents header elements such as 'Back', 'Save', and 'Settings' from being pushed too far to the edges.

---
*PR created automatically by Jules for task [6978460992158055199](https://jules.google.com/task/6978460992158055199) started by @John-Bell*