### PR TITLE
feat: calculate and link budget id on transactions

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -83,6 +83,7 @@ export interface Transaction {
     subCategory: string;
     type: 'income' | 'expense';
     icon: string;
+    budgetId?: string; // Links transaction to a specific budget
 }
 
 // --- New Table Interface ---
@@ -210,4 +211,18 @@ db.version(8).stores({
     taxRules: '&id',
     budgets: '&id, category, name, paymentSource, ownership',
     transactions: '&id, date, category, type'
+});
+
+// Schema version 9 - Link transactions to budgets
+db.version(9).stores({
+    profile: '&id',
+    accounts: '&id, ownerId, name, category, bonusRateActive, bonusEndDate',
+    incomes: '&id, ownerId, name, frequency, type, taxCategory',
+    scenarios: '&id, name',
+    settings: '&id',
+    monthlyArchives: '&id, month, year',
+    notifications: '&id, date, read',
+    taxRules: '&id',
+    budgets: '&id, category, name, paymentSource, ownership',
+    transactions: '&id, date, category, type, budgetId'
 });

--- a/src/pages/AddPaymentPage.tsx
+++ b/src/pages/AddPaymentPage.tsx
@@ -18,6 +18,12 @@ export function AddPaymentPage() {
     const handleSave = async (e: React.FormEvent) => {
         e.preventDefault();
 
+        // Find matching budget
+        const budgets = await db.budgets.toArray();
+        const matchingBudget = budgets.find(
+            b => b.category.toLowerCase() === category.toLowerCase() && b.name.toLowerCase() === subCategory.toLowerCase()
+        );
+
         await db.transactions.add({
             id: uuidv4(),
             date: new Date(date).getTime(),
@@ -26,7 +32,8 @@ export function AddPaymentPage() {
             category,
             subCategory,
             type,
-            icon: type === 'expense' ? 'shopping_cart' : 'payments'
+            icon: type === 'expense' ? 'shopping_cart' : 'payments',
+            budgetId: matchingBudget?.id
         });
 
         navigate('/transactions');

--- a/src/pages/EditPaymentPage.tsx
+++ b/src/pages/EditPaymentPage.tsx
@@ -34,6 +34,12 @@ export function EditPaymentPage() {
         e.preventDefault();
         if (!id) return;
 
+        // Find matching budget
+        const budgets = await db.budgets.toArray();
+        const matchingBudget = budgets.find(
+            b => b.category.toLowerCase() === category.toLowerCase() && b.name.toLowerCase() === subCategory.toLowerCase()
+        );
+
         await db.transactions.update(id, {
             date: new Date(date).getTime(),
             payee,
@@ -41,7 +47,8 @@ export function EditPaymentPage() {
             category,
             subCategory,
             type,
-            icon: type === 'expense' ? 'shopping_cart' : 'payments'
+            icon: type === 'expense' ? 'shopping_cart' : 'payments',
+            budgetId: matchingBudget?.id
         });
 
         navigate('/transactions');


### PR DESCRIPTION
This PR introduces an explicit link between transactions (payments) and budgets by calculating and storing a `budgetId` on each transaction. 

Previously, the association between payments and budgets relied solely on matching category and subcategory text fields. This update calculates the specific budget's UUID automatically upon creation or update of a transaction and saves it in the Dexie `transactions` store.

Key modifications:
- **Database Schema**: Added `budgetId` as an optional property on the `Transaction` interface and bumped the Dexie schema to version 9 to index it.
- **Add Payment**: Intercepts the `handleSave` flow to fetch budgets, performs a case-insensitive lookup based on category and subcategory, and attaches the matching `budgetId`.
- **Edit Payment**: Intercepts the `handleSave` flow similarly to recalculate the `budgetId` in case the transaction's category or subcategory has been altered.

---
*PR created automatically by Jules for task [18071012508216696827](https://jules.google.com/task/18071012508216696827) started by @John-Bell*