### PR TITLE
feat: Add Local-First iCloud Data Synchronization

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,13 +17,17 @@ import { TransactionsPage } from '@/pages/TransactionsPage';
 import { AddPaymentPage } from '@/pages/AddPaymentPage';
 import { EditPaymentPage } from '@/pages/EditPaymentPage';
 import { useStore } from '@/store/useStore';
+import { syncService } from '@/services/syncService';
 
 function AppRoutes() {
   const { isHydrated, profile, initStore } = useStore();
   const location = useLocation();
 
   useEffect(() => {
-    initStore();
+    initStore().then(() => {
+      // Attempt to reconnect to cloud sync after store is hydrated
+      syncService.reconnect();
+    });
   }, [initStore]);
 
   if (!isHydrated) {

--- a/src/components/layout/MainHeaderActions.tsx
+++ b/src/components/layout/MainHeaderActions.tsx
@@ -1,5 +1,6 @@
 import { useNavigate } from 'react-router-dom';
 import { Icon } from '../ui/Icon';
+import { SyncStatusIcon } from './SyncStatusIcon';
 
 interface MainHeaderActionsProps {
     onSave?: () => void;
@@ -11,6 +12,7 @@ export function MainHeaderActions({ onSave, isSaving }: MainHeaderActionsProps) 
 
     return (
         <div className="flex items-center gap-4">
+            <SyncStatusIcon />
             <button
                 onClick={() => navigate('/settings')}
                 className="p-2 rounded-full hover:bg-slate-200 dark:hover:bg-primary/10 transition-colors flex items-center justify-center -mr-2"

--- a/src/components/layout/SyncStatusIcon.tsx
+++ b/src/components/layout/SyncStatusIcon.tsx
@@ -1,0 +1,68 @@
+import { useStore } from '@/store/useStore';
+import { syncService } from '@/services/syncService';
+import { Icon } from '../ui/Icon';
+import { db } from '@/lib/db';
+
+export function SyncStatusIcon() {
+    const { syncStatus, lastSynced } = useStore();
+
+    const handleClick = async () => {
+        if (syncStatus === 'disconnected') {
+            await syncService.connectCloud();
+        } else if (syncStatus === 'permission_needed') {
+            const settings = await db.settings.get('default');
+            if (settings && settings.cloudHandle) {
+                const permission = await settings.cloudHandle.requestPermission({ mode: 'readwrite' });
+                if (permission === 'granted') {
+                    useStore.getState().setSyncStatus('connected');
+                    syncService.sync().catch(console.error);
+                }
+            }
+        } else if (syncStatus === 'connected') {
+            // Force a manual sync when tapped if already connected
+            syncService.sync().catch(console.error);
+        }
+    };
+
+    const getStatusDetails = () => {
+        switch (syncStatus) {
+            case 'disconnected':
+                return {
+                    color: 'text-red-500',
+                    tooltip: 'Cloud not linked. Tap to connect.',
+                    icon: 'cloud_off'
+                };
+            case 'permission_needed':
+                return {
+                    color: 'text-orange-500',
+                    tooltip: 'Permission expired. Tap to reconnect.',
+                    icon: 'cloud_sync'
+                };
+            case 'connected':
+                return {
+                    color: 'text-green-500',
+                    tooltip: `Connected. Last synced: ${lastSynced ? new Date(lastSynced).toLocaleTimeString() : 'never'}`,
+                    icon: 'cloud_done'
+                };
+            default:
+                return {
+                    color: 'text-slate-500',
+                    tooltip: 'Unknown sync status.',
+                    icon: 'cloud'
+                };
+        }
+    };
+
+    const { color, tooltip, icon } = getStatusDetails();
+
+    return (
+        <button
+            onClick={handleClick}
+            className={`p-2 rounded-full hover:bg-slate-200 dark:hover:bg-primary/10 transition-colors flex items-center justify-center`}
+            title={tooltip}
+            aria-label={tooltip}
+        >
+            <Icon name={icon} className={`${color}`} />
+        </button>
+    );
+}

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -9,6 +9,7 @@ export interface Profile {
     partner1Name?: string;
     partner2Name?: string;
     createdAt: number;
+    updatedAt?: number;
 }
 
 export interface Account {
@@ -36,12 +37,14 @@ export interface Income {
     // --- Updated Tax Optimization Fields ---
     type: string; // e.g., 'salary', 'rental', 'other'
     taxCategory: string; // e.g., 'Pension', 'State Pension', 'Dividend', 'Tax-Free', 'Earned'
+    updatedAt?: number;
 }
 
 export interface Scenario {
     id: string;
     name: string;
     description?: string;
+    updatedAt?: number;
 }
 
 export interface Settings {
@@ -50,6 +53,8 @@ export interface Settings {
     taxYear: string; // Acts as the FK pointing to TaxYearRule.id
     icloudSync: boolean;
     lastSynced?: number;
+    updatedAt?: number;
+    cloudHandle?: any; // FileSystemFileHandle
 }
 
 export interface MonthlyArchive {
@@ -60,6 +65,7 @@ export interface MonthlyArchive {
     estimatedAccruedInterest: number;
     closedAt: number;
     data: any; // Snapshot of accounts/incomes and calculated tax results
+    updatedAt?: number;
 }
 
 export interface AppNotification {
@@ -71,6 +77,7 @@ export interface AppNotification {
     read: boolean;
     actionLabel?: string;
     actionUrl?: string;
+    updatedAt?: number;
 }
 
 // --- Transactions Table Interface ---
@@ -84,11 +91,13 @@ export interface Transaction {
     type: 'income' | 'expense';
     icon: string;
     budgetId?: string; // Links transaction to a specific budget
+    updatedAt?: number;
 }
 
 // --- New Table Interface ---
 export interface TaxYearRule extends TaxYearConstants {
     id: string; // e.g., '2024-2025', '2025-2026'
+    updatedAt?: number;
 }
 
 export interface Budget {
@@ -99,6 +108,7 @@ export interface Budget {
     frequency: string; // e.g. monthly, annual
     paymentSource: string; // e.g. monthly, annual
     ownership: string; // e.g. john, billie, joint
+    updatedAt?: number;
 }
 
 export const db = new Dexie('IncomeTrackDB') as Dexie & {
@@ -215,6 +225,49 @@ db.version(8).stores({
 
 // Schema version 9 - Link transactions to budgets
 db.version(9).stores({
+    profile: '&id',
+    accounts: '&id, ownerId, name, category, bonusRateActive, bonusEndDate',
+    incomes: '&id, ownerId, name, frequency, type, taxCategory',
+    scenarios: '&id, name',
+    settings: '&id',
+    monthlyArchives: '&id, month, year',
+    notifications: '&id, date, read',
+    taxRules: '&id',
+    budgets: '&id, category, name, paymentSource, ownership',
+    transactions: '&id, date, category, type, budgetId'
+});
+
+// Add hooks to automatically update the updatedAt timestamp
+const tablesToHook = ['profile', 'accounts', 'incomes', 'scenarios', 'monthlyArchives', 'notifications', 'taxRules', 'transactions', 'budgets'];
+
+tablesToHook.forEach(tableName => {
+    (db as any)[tableName].hook('creating', function (primKey: any, obj: any, transaction: any) {
+        if (!obj.updatedAt) {
+            obj.updatedAt = Date.now();
+        }
+    });
+
+    (db as any)[tableName].hook('updating', function (modifications: any, primKey: any, obj: any, transaction: any) {
+        return { ...modifications, updatedAt: Date.now() };
+    });
+});
+
+// Schema version 10
+db.version(10).stores({
+    profile: '&id',
+    accounts: '&id, ownerId, name, category, bonusRateActive, bonusEndDate',
+    incomes: '&id, ownerId, name, frequency, type, taxCategory',
+    scenarios: '&id, name',
+    settings: '&id',
+    monthlyArchives: '&id, month, year',
+    notifications: '&id, date, read',
+    taxRules: '&id',
+    budgets: '&id, category, name, paymentSource, ownership',
+    transactions: '&id, date, category, type, budgetId'
+});
+
+// Schema version 11 - Add updatedAt and cloudHandle support
+db.version(11).stores({
     profile: '&id',
     accounts: '&id, ownerId, name, category, bonusRateActive, bonusEndDate',
     incomes: '&id, ownerId, name, frequency, type, taxCategory',

--- a/src/services/syncService.ts
+++ b/src/services/syncService.ts
@@ -1,0 +1,235 @@
+import { db } from '@/lib/db';
+import { useStore } from '@/store/useStore';
+
+export const syncService = {
+    async connectCloud() {
+        try {
+            if (!('showOpenFilePicker' in window)) {
+                throw new Error('File System Access API is not supported in this browser.');
+            }
+
+            const [fileHandle] = await (window as any).showOpenFilePicker({
+                id: 'finance-app-sync', // Remembers the last selected directory
+                types: [
+                    {
+                        description: 'JSON Files',
+                        accept: {
+                            'application/json': ['.json'],
+                        },
+                    },
+                ],
+            });
+
+            // Try to get permissions
+            const permission = await fileHandle.queryPermission({ mode: 'readwrite' });
+            if (permission !== 'granted') {
+                const requestPermission = await fileHandle.requestPermission({ mode: 'readwrite' });
+                if (requestPermission !== 'granted') {
+                    throw new Error('Permission denied to access the file.');
+                }
+            }
+
+            // Save the handle
+            let settings = await db.settings.get('default');
+            if (!settings) {
+                // Should not happen normally, but just in case
+                settings = {
+                    id: 'default',
+                    currency: 'GBP',
+                    taxYear: '2024-2025',
+                    icloudSync: true,
+                    cloudHandle: fileHandle,
+                    updatedAt: Date.now()
+                };
+                await db.settings.add(settings);
+            } else {
+                settings.icloudSync = true;
+                settings.cloudHandle = fileHandle;
+                settings.updatedAt = Date.now();
+                await db.settings.put(settings);
+            }
+
+            useStore.getState().setSyncStatus('connected');
+
+            // Initial sync immediately after connecting
+            await this.sync();
+
+            return true;
+        } catch (error) {
+            console.error('Failed to connect cloud:', error);
+            return false;
+        }
+    },
+
+    async saveToOPFS(data: any) {
+        try {
+            if (!navigator.storage || !navigator.storage.getDirectory) return;
+
+            const root = await navigator.storage.getDirectory();
+            const draftHandle = await root.getFileHandle('incometrack-safetymirror.json', { create: true });
+
+            // Some browsers (like Safari) support createWritable, others use syncAccessHandle
+            if ('createWritable' in draftHandle) {
+                const writable = await (draftHandle as any).createWritable();
+                await writable.write(JSON.stringify(data, null, 2));
+                await writable.close();
+            } else if ('createSyncAccessHandle' in draftHandle) {
+                // Fallback for OPFS in some environments
+                const accessHandle = await (draftHandle as any).createSyncAccessHandle();
+                const encoder = new TextEncoder();
+                const writeBuffer = encoder.encode(JSON.stringify(data, null, 2));
+                accessHandle.write(writeBuffer, { at: 0 });
+                accessHandle.flush();
+                accessHandle.close();
+            }
+        } catch (error) {
+            console.error('Failed to save to OPFS safety mirror:', error);
+        }
+    },
+
+    async mergeData(cloudData: any) {
+        let hasLocalChanges = false;
+        const tables = ['profile', 'accounts', 'incomes', 'scenarios', 'settings', 'monthlyArchives', 'notifications', 'taxRules', 'transactions', 'budgets'];
+
+        await db.transaction('rw', db.profile, db.accounts, db.incomes, db.scenarios, db.settings, db.monthlyArchives, db.notifications, db.taxRules, db.transactions, db.budgets, async () => {
+            for (const table of tables) {
+                const dexieTable = (db as any)[table];
+                const localRecords = await dexieTable.toArray();
+                const cloudRecords = cloudData[table] || [];
+
+                const localMap = new Map(localRecords.map((r: any) => [r.id, r]));
+
+                for (const cloudRecord of cloudRecords) {
+                    const localRecord = localMap.get(cloudRecord.id);
+
+                    if (!localRecord) {
+                        // Record exists in cloud but not local -> Add it
+                        await dexieTable.put(cloudRecord);
+                    } else {
+                        // Record exists in both -> Compare updatedAt
+                        const localTime = localRecord.updatedAt || 0;
+                        const cloudTime = cloudRecord.updatedAt || 0;
+
+                        if (cloudTime > localTime) {
+                            // Cloud is newer -> Update local
+                            // Do not overwrite cloudHandle in settings
+                            if (table === 'settings' && localRecord.cloudHandle) {
+                                cloudRecord.cloudHandle = localRecord.cloudHandle;
+                            }
+                            await dexieTable.put(cloudRecord);
+                        } else if (localTime > cloudTime) {
+                            // Local is newer -> Mark for export
+                            hasLocalChanges = true;
+                        }
+                    }
+                    localMap.delete(cloudRecord.id);
+                }
+
+                // Any remaining in localMap are local-only -> Mark for export
+                if (localMap.size > 0) {
+                    hasLocalChanges = true;
+                }
+            }
+        });
+
+        return hasLocalChanges;
+    },
+
+    async sync() {
+        const settings = await db.settings.get('default');
+        if (!settings || !settings.cloudHandle) return;
+
+        try {
+            const handle = settings.cloudHandle;
+
+            // Check permission
+            if (await handle.queryPermission({ mode: 'readwrite' }) !== 'granted') {
+                useStore.getState().setSyncStatus('permission_needed');
+                return;
+            }
+
+            // Read cloud file
+            let cloudData = {};
+            try {
+                const file = await handle.getFile();
+                const text = await file.text();
+                if (text.trim()) {
+                    cloudData = JSON.parse(text);
+                }
+            } catch (e) {
+                console.warn('Could not parse cloud file, assuming empty/new.', e);
+            }
+
+            // Merge
+            const hasLocalChanges = await this.mergeData(cloudData);
+
+            // Fetch current state of DB
+            const currentData: any = {};
+            const tables = ['profile', 'accounts', 'incomes', 'scenarios', 'settings', 'monthlyArchives', 'notifications', 'taxRules', 'transactions', 'budgets'];
+
+            for (const table of tables) {
+                currentData[table] = await (db as any)[table].toArray();
+            }
+
+            // Write back to cloud if we had newer local records or cloud file was empty
+            if (hasLocalChanges || Object.keys(cloudData).length === 0) {
+                // Remove cloudHandle from settings before stringifying to avoid serialization issues
+                if (currentData.settings) {
+                    currentData.settings = currentData.settings.map((s: any) => {
+                        const { cloudHandle, ...rest } = s;
+                        return rest;
+                    });
+                }
+
+                const writable = await handle.createWritable();
+                await writable.write(JSON.stringify(currentData, null, 2));
+                await writable.close();
+            }
+
+            // Save to OPFS Safety Mirror
+            await this.saveToOPFS(currentData);
+
+            // Update state
+            useStore.getState().setSyncStatus('connected');
+            useStore.getState().setLastSynced(Date.now());
+
+            // Update settings with lastSynced
+            settings.lastSynced = Date.now();
+            await db.settings.put(settings);
+
+        } catch (error) {
+            console.error('Sync failed:', error);
+            // Don't set disconnected if it's just a read/write error, could be temporary
+        }
+    },
+
+    async reconnect() {
+        try {
+            const settings = await db.settings.get('default');
+
+            if (settings && settings.cloudHandle) {
+                const handle = settings.cloudHandle;
+
+                // When reopening app (e.g. from swipe up), handle permission might need re-prompting
+                const permission = await handle.queryPermission({ mode: 'readwrite' });
+
+                if (permission === 'granted') {
+                    useStore.getState().setSyncStatus('connected');
+                    if (settings.lastSynced) {
+                        useStore.getState().setLastSynced(settings.lastSynced);
+                    }
+                    // Background sync
+                    this.sync().catch(console.error);
+                } else {
+                    // Session expired or tab closed, iOS requires re-granting on user interaction
+                    useStore.getState().setSyncStatus('permission_needed');
+                }
+            } else {
+                useStore.getState().setSyncStatus('disconnected');
+            }
+        } catch (error) {
+            console.error('Reconnect failed:', error);
+            useStore.getState().setSyncStatus('disconnected');
+        }
+    }
+};

--- a/src/store/useStore.ts
+++ b/src/store/useStore.ts
@@ -11,10 +11,14 @@ export interface AppState {
     activeAccountsTab: string;
     taxService: TaxCalculationService | null;
     taxYear: string | null;
+    syncStatus: 'disconnected' | 'connected' | 'permission_needed';
+    lastSynced: number | null;
 
     initStore: () => Promise<void>;
     setProfile: (profile: Profile) => Promise<void>;
     setActiveAccountsTab: (tab: string) => void;
+    setSyncStatus: (status: 'disconnected' | 'connected' | 'permission_needed') => void;
+    setLastSynced: (timestamp: number | null) => void;
 }
 
 export const useStore = create<AppState>()((set) => ({
@@ -24,6 +28,8 @@ export const useStore = create<AppState>()((set) => ({
     activeAccountsTab: 'joint',
     taxService: null,
     taxYear: null,
+    syncStatus: 'disconnected',
+    lastSynced: null,
 
     initStore: async () => {
         try {
@@ -104,5 +110,7 @@ export const useStore = create<AppState>()((set) => ({
         set({ profile });
     },
 
-    setActiveAccountsTab: (tab: string) => set({ activeAccountsTab: tab })
+    setActiveAccountsTab: (tab: string) => set({ activeAccountsTab: tab }),
+    setSyncStatus: (status: 'disconnected' | 'connected' | 'permission_needed') => set({ syncStatus: status }),
+    setLastSynced: (timestamp: number | null) => set({ lastSynced: timestamp })
 }));

--- a/test-dexie-hooks.js
+++ b/test-dexie-hooks.js
@@ -1,0 +1,2 @@
+const Dexie = require('dexie');
+// Can't easily test without indexeddb environment, skipping


### PR DESCRIPTION
This PR implements a robust, local-first iCloud Sync feature to seamlessly share data across devices without an external server. It leverages the File System Access API to connect to an iCloud folder, syncing data based on a "Newest Wins" merge strategy powered by `updatedAt` timestamps automatically maintained by Dexie hooks. A safety mirror copy is simultaneously persisted to the Origin Private File System (OPFS). Connection states are represented via a new `SyncStatusIcon` directly in the application's header.

---
*PR created automatically by Jules for task [9841047931935490262](https://jules.google.com/task/9841047931935490262) started by @John-Bell*