### PR TITLE
Add Data Import Service and Settings UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,11 @@
       "version": "0.0.0",
       "dependencies": {
         "@tailwindcss/vite": "^4.2.1",
+        "@types/papaparse": "^5.5.2",
         "clsx": "^2.1.1",
         "dexie": "^4.3.0",
         "dexie-react-hooks": "^4.2.0",
+        "papaparse": "^5.5.3",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-router-dom": "^7.13.1",
@@ -3400,10 +3402,18 @@
       "version": "24.10.13",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.13.tgz",
       "integrity": "sha512-oH72nZRfDv9lADUBSo104Aq7gPHpQZc4BTx38r9xf9pg5LfP6EzSyH2n7qFmmxRQXh7YlUXODcYsg6PuTDSxGg==",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/papaparse": {
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/@types/papaparse/-/papaparse-5.5.2.tgz",
+      "integrity": "sha512-gFnFp/JMzLHCwRf7tQHrNnfhN4eYBVYYI897CGX4MY1tzY9l2aLkVyx2IlKZ/SAqDbB3I1AOZW5gTMGGsqWliA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/react": {
@@ -7024,6 +7034,12 @@
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
+    "node_modules/papaparse": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.3.tgz",
+      "integrity": "sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A==",
+      "license": "MIT"
+    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
@@ -8451,7 +8467,6 @@
       "version": "7.16.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
       "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-      "devOptional": true,
       "license": "MIT"
     },
     "node_modules/unicode-canonical-property-names-ecmascript": {

--- a/package.json
+++ b/package.json
@@ -12,9 +12,11 @@
   },
   "dependencies": {
     "@tailwindcss/vite": "^4.2.1",
+    "@types/papaparse": "^5.5.2",
     "clsx": "^2.1.1",
     "dexie": "^4.3.0",
     "dexie-react-hooks": "^4.2.0",
+    "papaparse": "^5.5.3",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-router-dom": "^7.13.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,7 @@ import { AddBudgetPage } from '@/pages/AddBudgetPage';
 import { TransactionsPage } from '@/pages/TransactionsPage';
 import { AddPaymentPage } from '@/pages/AddPaymentPage';
 import { EditPaymentPage } from '@/pages/EditPaymentPage';
+import { ImportProcessor } from '@/pages/ImportProcessor';
 import { useStore } from '@/store/useStore';
 import { syncService } from '@/services/syncService';
 
@@ -49,6 +50,7 @@ function AppRoutes() {
       <Route path="/accounts/edit/:id" element={<EditAccountPage />} />
       <Route path="/scenarios" element={<ScenariosPage />} />
       <Route path="/settings" element={<SettingsPage />} />
+      <Route path="/settings/import/:table" element={<ImportProcessor />} />
       <Route path="/income" element={<IncomePage />} />
       <Route path="/income-config" element={<IncomeConfigPage />} />
       <Route path="/budgets" element={<BudgetsPage />} />

--- a/src/pages/ImportProcessor.tsx
+++ b/src/pages/ImportProcessor.tsx
@@ -1,0 +1,228 @@
+import React, { useState } from 'react';
+import { useNavigate, useParams } from 'react-router-dom';
+import { AppLayout } from '../components/layout/AppLayout';
+import { Header } from '../components/layout/Header';
+import { Icon } from '../components/ui/Icon';
+import { DataImportService } from '../services/DataImportService';
+
+const TABLE_SCHEMAS: Record<string, string[]> = {
+    accounts: ['id', 'name', 'balance', 'interestRate', 'category', 'ownerId', 'notes'],
+    budgets: ['id', 'category', 'name', 'amount', 'frequency', 'paymentSource', 'ownership', 'importMappingName'],
+    transactions: ['id', 'date', 'payee', 'amount', 'category', 'subCategory', 'type', 'icon', 'rawDesc']
+};
+
+export function ImportProcessor() {
+    const { table } = useParams<{ table: string }>();
+    const navigate = useNavigate();
+
+    const targetTable = table as 'accounts' | 'budgets' | 'transactions';
+    const isValidTable = targetTable && Object.keys(TABLE_SCHEMAS).includes(targetTable);
+
+    const [file, setFile] = useState<File | null>(null);
+    const [parsedData, setParsedData] = useState<any[]>([]);
+    const [headers, setHeaders] = useState<string[]>([]);
+    const [mapping, setMapping] = useState<Record<string, string>>({});
+    const [isImporting, setIsImporting] = useState(false);
+    const [error, setError] = useState<string | null>(null);
+
+    if (!isValidTable) {
+        return (
+            <AppLayout header={<Header title="Invalid Table" leftElement={<Icon name="arrow_back" onClick={() => navigate(-1)} />} />}>
+                <div className="p-4 text-red-500">Invalid table selected for import.</div>
+            </AppLayout>
+        );
+    }
+
+    const targetFields = TABLE_SCHEMAS[targetTable];
+
+    const handleFileSelect = async () => {
+        try {
+            setError(null);
+            // Feature detect the File System Access API
+            if ('showOpenFilePicker' in window) {
+                const [fileHandle] = await (window as any).showOpenFilePicker({
+                    types: [
+                        {
+                            description: 'CSV or JSON Files',
+                            accept: {
+                                'text/csv': ['.csv'],
+                                'application/json': ['.json'],
+                            },
+                        },
+                    ],
+                    multiple: false
+                });
+                const selectedFile = await fileHandle.getFile();
+                await processFile(selectedFile);
+            } else {
+                // Fallback for browsers that don't support showOpenFilePicker (like iOS Safari)
+                const input = document.createElement('input');
+                input.type = 'file';
+                input.accept = '.csv,.json';
+                input.onchange = async (e: any) => {
+                    const selectedFile = e.target.files[0];
+                    if (selectedFile) await processFile(selectedFile);
+                };
+                input.click();
+            }
+        } catch (err: any) {
+            // User cancelled or error occurred
+            if (err.name !== 'AbortError') {
+                setError(err.message || 'Failed to open file picker.');
+            }
+        }
+    };
+
+    const processFile = async (selectedFile: File) => {
+        setFile(selectedFile);
+        try {
+            const data = await DataImportService.parseFile(selectedFile);
+            setParsedData(data);
+            if (data.length > 0) {
+                const sourceHeaders = Object.keys(data[0]);
+                setHeaders(sourceHeaders);
+
+                // Auto-map where possible (case-insensitive)
+                const initialMapping: Record<string, string> = {};
+                sourceHeaders.forEach(header => {
+                    const matchedTarget = targetFields.find(f => f.toLowerCase() === header.toLowerCase());
+                    if (matchedTarget) {
+                        initialMapping[header] = matchedTarget;
+                    }
+                });
+                setMapping(initialMapping);
+            }
+        } catch (err: any) {
+            setError(err.message || 'Error parsing file.');
+        }
+    };
+
+    const handleMappingChange = (sourceField: string, targetField: string) => {
+        setMapping(prev => ({
+            ...prev,
+            [sourceField]: targetField
+        }));
+    };
+
+    const handleImport = async () => {
+        if (!file || parsedData.length === 0) return;
+        setIsImporting(true);
+        setError(null);
+        try {
+            await DataImportService.importData(targetTable, parsedData, file.name, mapping);
+            navigate(-1); // Go back on success
+        } catch (err: any) {
+            setError(err.message || 'An error occurred during import.');
+            setIsImporting(false);
+        }
+    };
+
+    return (
+        <AppLayout
+            header={
+                <Header
+                    title={`Import ${targetTable.charAt(0).toUpperCase() + targetTable.slice(1)}`}
+                    leftElement={<Icon name="arrow_back" className="text-primary text-2xl cursor-pointer" onClick={() => navigate(-1)} />}
+                    className="bg-transparent backdrop-blur-md"
+                />
+            }
+        >
+            <div className="flex-1 w-full mx-auto p-4 space-y-6">
+                {!file ? (
+                    <div className="flex flex-col items-center justify-center py-12 border-2 border-dashed border-slate-300 dark:border-slate-700 rounded-xl">
+                        <Icon name="upload_file" className="text-6xl text-slate-400 mb-4" />
+                        <p className="text-slate-600 dark:text-slate-300 mb-4 text-center">Select a CSV or JSON file to import</p>
+                        <button
+                            onClick={handleFileSelect}
+                            className="bg-primary text-white px-6 py-2 rounded-lg font-semibold hover:bg-primary/90 transition-colors"
+                        >
+                            Select File
+                        </button>
+                        {error && <p className="text-red-500 mt-4">{error}</p>}
+                    </div>
+                ) : (
+                    <>
+                        <div className="bg-white dark:bg-slate-900/40 p-4 rounded-xl border border-slate-200 dark:border-primary/5">
+                            <h3 className="font-semibold mb-2">File Info</h3>
+                            <p className="text-sm text-slate-600 dark:text-slate-400">Name: {file.name}</p>
+                            <p className="text-sm text-slate-600 dark:text-slate-400">Rows: {parsedData.length}</p>
+                        </div>
+
+                        {parsedData.length > 0 && (
+                            <div className="space-y-4">
+                                <div>
+                                    <h3 className="font-semibold mb-2">Column Mapping</h3>
+                                    <p className="text-xs text-slate-500 mb-4">Map your file columns to the database fields.</p>
+                                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                        {headers.map(header => (
+                                            <div key={header} className="flex items-center space-x-2">
+                                                <div className="flex-1 text-sm font-medium truncate" title={header}>{header}</div>
+                                                <Icon name="arrow_forward" className="text-slate-400" />
+                                                <select
+                                                    className="flex-1 bg-slate-50 dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-md p-2 text-sm"
+                                                    value={mapping[header] || ''}
+                                                    onChange={(e) => handleMappingChange(header, e.target.value)}
+                                                >
+                                                    <option value="">-- Ignore --</option>
+                                                    {targetFields.map(field => (
+                                                        <option key={field} value={field}>{field}</option>
+                                                    ))}
+                                                </select>
+                                            </div>
+                                        ))}
+                                    </div>
+                                </div>
+
+                                <div>
+                                    <h3 className="font-semibold mb-2">Pre-Import Preview (First 5 rows)</h3>
+                                    <div className="overflow-x-auto border border-slate-200 dark:border-slate-700 rounded-lg">
+                                        <table className="w-full text-sm text-left">
+                                            <thead className="bg-slate-50 dark:bg-slate-800 border-b border-slate-200 dark:border-slate-700">
+                                                <tr>
+                                                    {headers.map((header, idx) => (
+                                                        <th key={idx} className="p-2 font-medium">
+                                                            <div>{header}</div>
+                                                            <div className="text-xs text-primary font-normal">{mapping[header] || 'Ignored'}</div>
+                                                        </th>
+                                                    ))}
+                                                </tr>
+                                            </thead>
+                                            <tbody>
+                                                {parsedData.slice(0, 5).map((row, idx) => (
+                                                    <tr key={idx} className="border-b border-slate-100 dark:border-slate-800/50">
+                                                        {headers.map((header, hIdx) => (
+                                                            <td key={hIdx} className="p-2 truncate max-w-[150px]">{String(row[header] || '')}</td>
+                                                        ))}
+                                                    </tr>
+                                                ))}
+                                            </tbody>
+                                        </table>
+                                    </div>
+                                </div>
+
+                                {error && <p className="text-red-500">{error}</p>}
+
+                                <div className="flex gap-4 pt-4">
+                                    <button
+                                        onClick={() => { setFile(null); setParsedData([]); }}
+                                        className="flex-1 bg-slate-200 dark:bg-slate-700 text-slate-800 dark:text-white px-4 py-3 rounded-lg font-semibold hover:bg-slate-300 dark:hover:bg-slate-600 transition-colors"
+                                        disabled={isImporting}
+                                    >
+                                        Cancel
+                                    </button>
+                                    <button
+                                        onClick={handleImport}
+                                        disabled={isImporting}
+                                        className="flex-1 bg-primary text-white px-4 py-3 rounded-lg font-semibold hover:bg-primary/90 transition-colors disabled:opacity-50"
+                                    >
+                                        {isImporting ? 'Importing...' : 'Confirm Import'}
+                                    </button>
+                                </div>
+                            </div>
+                        )}
+                    </>
+                )}
+            </div>
+        </AppLayout>
+    );
+}

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -41,6 +41,47 @@ export function SettingsPage() {
                 </section>
 
                 <section className="mt-8 px-4">
+                    <h2 className="text-xs font-bold uppercase tracking-widest text-slate-500 dark:text-primary/60 mb-3 px-1">Data Management</h2>
+                    <div className="bg-white dark:bg-slate-900/40 border border-slate-200 dark:border-primary/5 rounded-xl divide-y divide-slate-100 dark:divide-primary/5">
+                        <Link to="/settings/import/accounts" className="flex items-center justify-between p-4 hover:bg-slate-50 dark:hover:bg-primary/10 transition-colors cursor-pointer">
+                            <div className="flex items-center gap-4">
+                                <div className="flex items-center justify-center w-10 h-10 rounded-lg bg-slate-100 dark:bg-primary/5 text-slate-600 dark:text-primary/80">
+                                    <Icon name="account_balance" />
+                                </div>
+                                <p className="font-medium">Import Accounts</p>
+                            </div>
+                            <div className="flex items-center gap-2 text-primary">
+                                <Icon name="chevron_right" className="text-sm" />
+                            </div>
+                        </Link>
+
+                        <Link to="/settings/import/budgets" className="flex items-center justify-between p-4 hover:bg-slate-50 dark:hover:bg-primary/10 transition-colors cursor-pointer">
+                            <div className="flex items-center gap-4">
+                                <div className="flex items-center justify-center w-10 h-10 rounded-lg bg-slate-100 dark:bg-primary/5 text-slate-600 dark:text-primary/80">
+                                    <Icon name="account_balance_wallet" />
+                                </div>
+                                <p className="font-medium">Import Budgets</p>
+                            </div>
+                            <div className="flex items-center gap-2 text-primary">
+                                <Icon name="chevron_right" className="text-sm" />
+                            </div>
+                        </Link>
+
+                        <Link to="/settings/import/transactions" className="flex items-center justify-between p-4 hover:bg-slate-50 dark:hover:bg-primary/10 transition-colors cursor-pointer">
+                            <div className="flex items-center gap-4">
+                                <div className="flex items-center justify-center w-10 h-10 rounded-lg bg-slate-100 dark:bg-primary/5 text-slate-600 dark:text-primary/80">
+                                    <Icon name="receipt_long" />
+                                </div>
+                                <p className="font-medium">Import Transactions</p>
+                            </div>
+                            <div className="flex items-center gap-2 text-primary">
+                                <Icon name="chevron_right" className="text-sm" />
+                            </div>
+                        </Link>
+                    </div>
+                </section>
+
+                <section className="mt-8 px-4">
                     <h2 className="text-xs font-bold uppercase tracking-widest text-slate-500 dark:text-primary/60 mb-3 px-1">Monthly Close-Out</h2>
                     <MonthlyCloseOut
                         description="Archives current balances and interest rates to history and prepares the ledger for the new month. This action is final."

--- a/src/services/DataImportService.ts
+++ b/src/services/DataImportService.ts
@@ -1,0 +1,149 @@
+import Papa from 'papaparse';
+import { db, type Budget } from '../lib/db';
+
+export class DataImportService {
+    /**
+     * Parse a CSV or JSON file and return an array of objects.
+     */
+    static async parseFile(file: File): Promise<any[]> {
+        return new Promise((resolve, reject) => {
+            if (file.name.endsWith('.json')) {
+                const reader = new FileReader();
+                reader.onload = (e) => {
+                    try {
+                        const json = JSON.parse(e.target?.result as string);
+                        resolve(Array.isArray(json) ? json : [json]);
+                    } catch (err) {
+                        reject(new Error('Failed to parse JSON file'));
+                    }
+                };
+                reader.onerror = () => reject(new Error('Failed to read file'));
+                reader.readAsText(file);
+            } else if (file.name.endsWith('.csv')) {
+                Papa.parse(file, {
+                    header: true,
+                    skipEmptyLines: true,
+                    complete: (results) => {
+                        resolve(results.data);
+                    },
+                    error: (error) => {
+                        reject(error);
+                    }
+                });
+            } else {
+                reject(new Error('Unsupported file type. Please use CSV or JSON.'));
+            }
+        });
+    }
+
+    /**
+     * Generate a deterministic string hash for ID fallback.
+     */
+    static generateDeterministicId(row: any, targetTable: string): string {
+        let sourceString = '';
+        if (targetTable === 'transactions') {
+            sourceString = `${row.date || ''}-${row.amount || ''}-${row.payee || ''}-${row.rawDesc || ''}-${row.category || ''}`;
+        } else if (targetTable === 'budgets') {
+            sourceString = `${row.category || ''}-${row.name || ''}-${row.amount || ''}`;
+        } else if (targetTable === 'accounts') {
+            sourceString = `${row.name || ''}-${row.category || ''}-${row.ownerId || ''}`;
+        } else {
+            sourceString = JSON.stringify(row);
+        }
+
+        let hash = 0;
+        for (let i = 0; i < sourceString.length; i++) {
+            const char = sourceString.charCodeAt(i);
+            hash = ((hash << 5) - hash) + char;
+            hash = hash & hash; // Convert to 32bit integer
+        }
+        return `import-${targetTable}-${Math.abs(hash)}`;
+    }
+
+    static async importData(
+        targetTable: 'accounts' | 'budgets' | 'transactions',
+        data: any[],
+        filename: string,
+        fieldMapping: Record<string, string>
+    ): Promise<number> {
+        if (!data || data.length === 0) return 0;
+
+        const importId = filename;
+        const now = Date.now();
+        const recordsToInsert: any[] = [];
+
+        // Pre-fetch budgets if we are importing transactions to handle linking
+        let budgets: Budget[] = [];
+        if (targetTable === 'transactions') {
+            budgets = await db.budgets.toArray();
+        }
+
+        for (const row of data) {
+            // Map the source row to our database schema using fieldMapping
+            const mappedRow: any = {};
+
+            for (const [sourceKey, targetKey] of Object.entries(fieldMapping)) {
+                if (targetKey && row[sourceKey] !== undefined && row[sourceKey] !== '') {
+                    // Type conversions based on target keys
+                    if (targetKey === 'amount' || targetKey === 'balance' || targetKey === 'interestRate') {
+                        const parsed = parseFloat(String(row[sourceKey]).replace(/[^0-9.-]+/g, ""));
+                        mappedRow[targetKey] = isNaN(parsed) ? 0 : parsed;
+                    } else if (targetKey === 'date' || targetKey === 'bonusEndDate') {
+                        const parsedDate = new Date(row[sourceKey]).getTime();
+                        mappedRow[targetKey] = isNaN(parsedDate) ? Date.now() : parsedDate;
+                    } else if (targetKey === 'bonusRateActive') {
+                        mappedRow[targetKey] = String(row[sourceKey]).toLowerCase() === 'true';
+                    } else {
+                        mappedRow[targetKey] = row[sourceKey];
+                    }
+                }
+            }
+
+            // Determine ID
+            if (!mappedRow.id) {
+                mappedRow.id = this.generateDeterministicId(mappedRow, targetTable);
+            }
+
+            // Set metadata
+            mappedRow.importId = importId;
+            mappedRow.updatedAt = now;
+
+            // Table-specific logic
+            if (targetTable === 'transactions') {
+                if (!mappedRow.date) mappedRow.date = now;
+                if (!mappedRow.type) mappedRow.type = mappedRow.amount >= 0 ? 'income' : 'expense';
+
+                // Transaction Linking logic
+                if (mappedRow.category && !mappedRow.budgetId) {
+                    const categoryLower = mappedRow.category.toLowerCase();
+                    const matchedBudget = budgets.find(b =>
+                        (b.importMappingName && b.importMappingName.toLowerCase() === categoryLower) ||
+                        (b.name && b.name.toLowerCase() === categoryLower) ||
+                        (b.category && b.category.toLowerCase() === categoryLower)
+                    );
+
+                    if (matchedBudget) {
+                        mappedRow.budgetId = matchedBudget.id;
+                    }
+                }
+            } else if (targetTable === 'budgets') {
+                if (!mappedRow.frequency) mappedRow.frequency = 'monthly';
+                if (!mappedRow.paymentSource) mappedRow.paymentSource = 'monthly';
+                if (!mappedRow.ownership) mappedRow.ownership = 'joint';
+            } else if (targetTable === 'accounts') {
+                if (!mappedRow.ownerId) mappedRow.ownerId = 'default';
+                if (mappedRow.balance === undefined) mappedRow.balance = 0;
+                if (mappedRow.interestRate === undefined) mappedRow.interestRate = 0;
+            }
+
+            recordsToInsert.push(mappedRow);
+        }
+
+        // Perform bulk upsert in a transaction
+        await db.transaction('rw', db[targetTable], async () => {
+            await db[targetTable].bulkPut(recordsToInsert);
+        });
+
+        return recordsToInsert.length;
+    }
+}


### PR DESCRIPTION
This implements the requested Data Import Service and UI for Accounts, Budgets, and Transactions. The UI resides under "Settings -> Data Management" and uses a push/pop pattern. The processor parses CSV and JSON locally using `papaparse`, displays a preview, and allows column mapping. Identity hashing and transaction-budget linking rules are fully respected. All interactions use `dexie.bulkPut` to ensure duplicate imports act as upserts.

---
*PR created automatically by Jules for task [13398886817143881613](https://jules.google.com/task/13398886817143881613) started by @John-Bell*