### PR TITLE
fix: resolve typescript build errors

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -170,13 +170,13 @@ export const initDb = async () => {
 const tablesToHook = ['profile', 'accounts', 'incomes', 'scenarios', 'monthlyArchives', 'notifications', 'taxRules', 'transactions', 'budgets'];
 
 tablesToHook.forEach(tableName => {
-    (db as any)[tableName].hook('creating', function (primKey: any, obj: any, transaction: any) {
+    (db as any)[tableName].hook('creating', function (_primKey: any, obj: any, _transaction: any) {
         if (!obj.updatedAt) {
             obj.updatedAt = Date.now();
         }
     });
 
-    (db as any)[tableName].hook('updating', function (modifications: any, primKey: any, obj: any, transaction: any) {
+    (db as any)[tableName].hook('updating', function (modifications: any, _primKey: any, _obj: any, _transaction: any) {
         if (modifications.hasOwnProperty('updatedAt')) {
             return modifications;
         }

--- a/src/pages/ImportProcessor.tsx
+++ b/src/pages/ImportProcessor.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { AppLayout } from '../components/layout/AppLayout';
 import { Header } from '../components/layout/Header';

--- a/src/services/DataImportService.test.ts
+++ b/src/services/DataImportService.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { DataImportService } from './DataImportService';
 import { db } from '../lib/db';
 

--- a/src/services/DataImportService.ts
+++ b/src/services/DataImportService.ts
@@ -141,7 +141,7 @@ export class DataImportService {
 
         // Perform bulk upsert in a transaction
         await db.transaction('rw', db[targetTable], async () => {
-            await db[targetTable].bulkPut(recordsToInsert);
+            await (db as any)[targetTable].bulkPut(recordsToInsert);
         });
 
         return recordsToInsert.length;

--- a/src/services/syncService.ts
+++ b/src/services/syncService.ts
@@ -87,11 +87,13 @@ export const syncService = {
         }
     },
 
-    async mergeData(cloudData: any) {
+    async mergeData(cloudData: Record<string, any[]>) {
         let hasLocalChanges = false;
         const tables = ['profile', 'accounts', 'incomes', 'scenarios', 'settings', 'monthlyArchives', 'notifications', 'taxRules', 'transactions', 'budgets'];
 
-        await db.transaction('rw', db.profile, db.accounts, db.incomes, db.scenarios, db.settings, db.monthlyArchives, db.notifications, db.taxRules, db.transactions, db.budgets, async () => {
+        const tableList = [db.profile, db.accounts, db.incomes, db.scenarios, db.settings, db.monthlyArchives, db.notifications, db.taxRules, db.transactions, db.budgets];
+
+        await db.transaction('rw', tableList, async () => {
             for (const table of tables) {
                 const dexieTable = (db as any)[table];
                 const localRecords = await dexieTable.toArray();
@@ -99,7 +101,8 @@ export const syncService = {
 
                 const localMap = new Map(localRecords.map((r: any) => [r.id, r]));
 
-                for (const cloudRecord of cloudRecords) {
+                for (let i = 0; i < cloudRecords.length; i++) {
+                    const cloudRecord = cloudRecords[i] as any;
                     const localRecord = localMap.get(cloudRecord.id);
 
                     if (!localRecord) {
@@ -107,14 +110,14 @@ export const syncService = {
                         await dexieTable.put(cloudRecord);
                     } else {
                         // Record exists in both -> Compare updatedAt
-                        const localTime = localRecord.updatedAt || 0;
-                        const cloudTime = cloudRecord.updatedAt || 0;
+                        const localTime = (localRecord as any).updatedAt || 0;
+                        const cloudTime = (cloudRecord as any).updatedAt || 0;
 
                         if (cloudTime > localTime) {
                             // Cloud is newer -> Update local
                             // Do not overwrite cloudHandle in settings
-                            if (table === 'settings' && localRecord.cloudHandle) {
-                                cloudRecord.cloudHandle = localRecord.cloudHandle;
+                            if (table === 'settings' && (localRecord as any).cloudHandle) {
+                                (cloudRecord as any).cloudHandle = (localRecord as any).cloudHandle;
                             }
                             await dexieTable.put(cloudRecord);
                         } else if (localTime > cloudTime) {
@@ -149,7 +152,7 @@ export const syncService = {
             }
 
             // Read cloud file
-            let cloudData = {};
+            let cloudData: Record<string, any[]> = {};
             try {
                 const file = await handle.getFile();
                 const text = await file.text();


### PR DESCRIPTION
This PR addresses GitHub Actions CI pipeline failures caused by TypeScript compilation errors. 

**Key Changes:**
* Resolved `TS6133` unused variable errors by prefixing hook parameters with `_` and removing unnecessary imports.
* Addressed `TS2349` callable expression errors by properly typing dynamic Dexie table access.
* Fixed `TS2554` and `TS2339` errors in the `syncService.ts` related to excessive argument counts for Dexie transactions (by passing an array) and resolving generic object property access for `updatedAt` by providing proper `any` typing.

The build (`npm run build`) and test suite (`npm run test`) now pass successfully.

---
*PR created automatically by Jules for task [15711367324728558111](https://jules.google.com/task/15711367324728558111) started by @John-Bell*