### PR TITLE
fix: make header cloud icon explicitly clickable

### DIFF
--- a/src/components/layout/SyncStatusIcon.tsx
+++ b/src/components/layout/SyncStatusIcon.tsx
@@ -57,8 +57,9 @@ export function SyncStatusIcon() {
 
     return (
         <button
+            type="button"
             onClick={handleClick}
-            className={`p-2 rounded-full hover:bg-slate-200 dark:hover:bg-primary/10 transition-colors flex items-center justify-center`}
+            className={`p-2 rounded-full hover:bg-slate-200 dark:hover:bg-primary/10 transition-colors flex items-center justify-center cursor-pointer`}
             title={tooltip}
             aria-label={tooltip}
         >


### PR DESCRIPTION
Added `type="button"` to the button element in `SyncStatusIcon.tsx` to prevent it from inheriting default submit behavior if wrapped in forms or triggering edge-case browser parsing issues. Also added the `cursor-pointer` class explicitly to give the user immediate visual feedback that it is clickable. All tests pass and the element has been verified via Playwright.

---
*PR created automatically by Jules for task [6107814444617612597](https://jules.google.com/task/6107814444617612597) started by @John-Bell*