### PR TITLE
Add fallback file pickers in backupService for iOS PWA support

### DIFF
--- a/src/services/backupService.ts
+++ b/src/services/backupService.ts
@@ -23,14 +23,23 @@ export const exportDatabase = async () => {
         };
 
         const blob = new Blob([JSON.stringify(backup, null, 2)], { type: 'application/json' });
+        const suggestedName = `incometrack-backup-${new Date().toISOString().split('T')[0]}.json`;
 
-        // Check if showSaveFilePicker is supported (mostly Chrome/Edge right now)
         if (!('showSaveFilePicker' in window)) {
-            throw new Error('File System Access API is not supported in this browser.');
+            // Fallback for browsers that don't support showSaveFilePicker (like iOS Safari)
+            const url = URL.createObjectURL(blob);
+            const a = document.createElement('a');
+            a.href = url;
+            a.download = suggestedName;
+            document.body.appendChild(a);
+            a.click();
+            document.body.removeChild(a);
+            setTimeout(() => URL.revokeObjectURL(url), 1000);
+            return true;
         }
 
         const fileHandle = await (window as any).showSaveFilePicker({
-            suggestedName: `incometrack-backup-${new Date().toISOString().split('T')[0]}.json`,
+            suggestedName,
             types: [
                 {
                     description: 'JSON Files',
@@ -54,22 +63,41 @@ export const exportDatabase = async () => {
 
 export const importDatabase = async () => {
     try {
+        let file: File;
+
         if (!('showOpenFilePicker' in window)) {
-            throw new Error('File System Access API is not supported in this browser.');
+            // Fallback for browsers that don't support showOpenFilePicker (like iOS Safari)
+            file = await new Promise<File>((resolve, reject) => {
+                const input = document.createElement('input');
+                input.type = 'file';
+                input.accept = '.json,.chaser';
+                input.onchange = (e: any) => {
+                    const selectedFile = e.target.files[0];
+                    if (selectedFile) {
+                        resolve(selectedFile);
+                    } else {
+                        reject(new Error('No file selected'));
+                    }
+                };
+                input.oncancel = () => {
+                    reject(new Error('File selection cancelled'));
+                };
+                input.click();
+            });
+        } else {
+            const [fileHandle] = await (window as any).showOpenFilePicker({
+                types: [
+                    {
+                        description: 'JSON Files',
+                        accept: {
+                            'application/json': ['.json'],
+                        },
+                    },
+                ],
+            });
+            file = await fileHandle.getFile();
         }
 
-        const [fileHandle] = await (window as any).showOpenFilePicker({
-            types: [
-                {
-                    description: 'JSON Files',
-                    accept: {
-                        'application/json': ['.json'],
-                    },
-                },
-            ],
-        });
-
-        const file = await fileHandle.getFile();
         const contents = await file.text();
         const backup: BackupData = JSON.parse(contents);
 


### PR DESCRIPTION
Added HTML5 native fallbacks for file imports and exports when the browser lacks support for the File System Access API (`showOpenFilePicker` and `showSaveFilePicker`), enabling existing configuration loading and backup downloads on iOS devices.

---
*PR created automatically by Jules for task [17987380133382127958](https://jules.google.com/task/17987380133382127958) started by @John-Bell*