### PR TITLE
feat: automatically sync to cloud on local database changes

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import { EditPaymentPage } from '@/pages/EditPaymentPage';
 import { ImportProcessor } from '@/pages/ImportProcessor';
 import { useStore } from '@/store/useStore';
 import { syncService } from '@/services/syncService';
+import { dbHooks } from '@/lib/db';
 
 function AppRoutes() {
   const { isHydrated, profile, initStore } = useStore();
@@ -28,6 +29,9 @@ function AppRoutes() {
     initStore().then(() => {
       // Attempt to reconnect to cloud sync after store is hydrated
       syncService.reconnect();
+
+      // Wire up auto-sync on local DB changes
+      dbHooks.onLocalChange = () => syncService.autoSync();
     });
   }, [initStore]);
 

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -166,6 +166,10 @@ export const initDb = async () => {
     }
 };
 
+export const dbHooks = {
+    onLocalChange: () => {}
+};
+
 // Add hooks to automatically update the updatedAt timestamp
 const tablesToHook = ['profile', 'accounts', 'incomes', 'scenarios', 'monthlyArchives', 'notifications', 'taxRules', 'transactions', 'budgets'];
 
@@ -174,13 +178,19 @@ tablesToHook.forEach(tableName => {
         if (!obj.updatedAt) {
             obj.updatedAt = Date.now();
         }
+        dbHooks.onLocalChange();
     });
 
     (db as any)[tableName].hook('updating', function (modifications: any, _primKey: any, _obj: any, _transaction: any) {
+        dbHooks.onLocalChange();
         if (modifications.hasOwnProperty('updatedAt')) {
             return modifications;
         }
         return { ...modifications, updatedAt: Date.now() };
+    });
+
+    (db as any)[tableName].hook('deleting', function (_primKey: any, _obj: any, _transaction: any) {
+        dbHooks.onLocalChange();
     });
 });
 

--- a/src/services/syncService.ts
+++ b/src/services/syncService.ts
@@ -77,6 +77,20 @@ const promptOptions = (title: string, message: string, options: { label: string,
 };
 
 export const syncService = {
+    _syncTimeout: null as ReturnType<typeof setTimeout> | null,
+
+    autoSync() {
+        if (this._syncTimeout) {
+            clearTimeout(this._syncTimeout);
+        }
+        this._syncTimeout = setTimeout(async () => {
+            const status = useStore.getState().syncStatus;
+            if (status === 'connected') {
+                await this.sync();
+            }
+        }, 2000);
+    },
+
     async createNewCloudFile() {
         try {
             if (!('showSaveFilePicker' in window)) {


### PR DESCRIPTION
This PR adds automatic cloud sync when local data changes. The database hooks listen for any create, update or delete actions from Dexie and triggers a debounced sync request in `syncService`. If the app is connected to the cloud (green sync icon), it seamlessly synchronizes the data in the background.

---
*PR created automatically by Jules for task [11385532304405043735](https://jules.google.com/task/11385532304405043735) started by @John-Bell*