### PR TITLE
fix: PWA icon and standalone mode detection on GitHub Pages

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#ffffff" />
     <title>The Chaser - Tax Optimizer</title>
-    <link rel="apple-touch-icon" href="/vite.svg">
+    <link rel="apple-touch-icon" href="/incometrack/apple-touch-icon.png">
     <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@200..800&display=swap" rel="stylesheet"/>
     <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet"/>
   </head>

--- a/src/services/syncService.ts
+++ b/src/services/syncService.ts
@@ -140,7 +140,7 @@ export const syncService = {
 
     async connectCloud() {
         try {
-            if (!window.isSecureContext || !('showOpenFilePicker' in window) || !('showSaveFilePicker' in window)) {
+            if (!window.isSecureContext || !('showOpenFilePicker' in window) || !('showSaveFilePicker' in window) || !(window.navigator as any).standalone) {
                 await promptOptions(
                     'Installation Guide',
                     'To enable cloud sync, please install this app to your Home Screen: Tap the Share icon, then select "Add to Home Screen". Note: Secure context (HTTPS) is required.',

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,25 +18,26 @@ export default defineConfig({
         name: 'The Chaser - Tax Optimizer',
         short_name: 'The Chaser',
         description: 'Optimize your taxes and income tracking',
+        background_color: '#ffffff',
         theme_color: '#ffffff',
         start_url: '/incometrack/',
         scope: '/incometrack/',
         display: 'standalone',
         icons: [
           {
-            src: 'pwa-192x192.png',
+            src: '/incometrack/pwa-192x192.png',
             sizes: '192x192',
             type: 'image/png',
             purpose: 'any maskable'
           },
           {
-            src: 'pwa-512x512.png',
+            src: '/incometrack/pwa-512x512.png',
             sizes: '512x512',
             type: 'image/png',
             purpose: 'any maskable'
           },
           {
-            src: 'apple-touch-icon.png'
+            src: '/incometrack/apple-touch-icon.png'
           }
         ]
       }


### PR DESCRIPTION
This commit resolves the issue where the PWA shows a generic gray icon and incorrectly displays the Installation Guide when deployed to GitHub Pages. It addresses incorrect path referencing for manifest icons, lack of splash screen color specification, and correctly introduces a `navigator.standalone` check for accurate standalone PWA mode detection on iOS devices.

---
*PR created automatically by Jules for task [10701369281827259945](https://jules.google.com/task/10701369281827259945) started by @John-Bell*