### PR TITLE
Fix iOS 26 PWA icons and File System API sync constraints

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,11 +2,11 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <link rel="icon" type="image/svg+xml" href="/incometrack/favicon.svg?v=1" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="theme-color" content="#ffffff" />
     <title>The Chaser - Tax Optimizer</title>
-    <link rel="apple-touch-icon" href="/incometrack/apple-touch-icon.png">
+    <link rel="apple-touch-icon" href="/incometrack/apple-touch-icon.png?v=1">
     <link href="https://fonts.googleapis.com/css2?family=Manrope:wght@200..800&display=swap" rel="stylesheet"/>
     <link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet"/>
   </head>

--- a/src/services/backupService.ts
+++ b/src/services/backupService.ts
@@ -59,9 +59,18 @@ export const exportDatabase = async () => {
             ],
         });
 
-        const writable = await fileHandle.createWritable();
-        await writable.write(blob);
-        await writable.close();
+        try {
+            const writable = await fileHandle.createWritable();
+            await writable.write(blob);
+            await writable.close();
+        } catch (writeError: any) {
+            if (writeError.name === 'QuotaExceededError' || (writeError.message && writeError.message.toLowerCase().includes('quota'))) {
+                alert('Storage quota exceeded. Please free up space on your device.');
+                throw writeError;
+            } else {
+                throw writeError;
+            }
+        }
 
         return true;
     } catch (error) {

--- a/src/services/syncService.ts
+++ b/src/services/syncService.ts
@@ -61,7 +61,12 @@ export const syncService = {
         this._syncTimeout = setTimeout(async () => {
             const status = useStore.getState().syncStatus;
             if (status === 'connected') {
-                await this.sync();
+                if ((window.navigator as any).standalone) {
+                    // iOS PWA requires a user gesture to write files.
+                    useStore.getState().setSyncStatus('permission_needed');
+                } else {
+                    await this.sync();
+                }
             }
         }, 2000);
     },
@@ -353,9 +358,18 @@ export const syncService = {
                 });
             }
 
-            const writable = await handle.createWritable();
-            await writable.write(JSON.stringify(currentData, null, 2));
-            await writable.close();
+            try {
+                const writable = await handle.createWritable();
+                await writable.write(JSON.stringify(currentData, null, 2));
+                await writable.close();
+            } catch (writeError: any) {
+                if (writeError.name === 'QuotaExceededError' || (writeError.message && writeError.message.toLowerCase().includes('quota'))) {
+                    alert('Storage quota exceeded. Please free up space on your device.');
+                    throw writeError;
+                } else {
+                    throw writeError;
+                }
+            }
 
             // Save to OPFS Safety Mirror
             await this.saveToOPFS(currentData);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
     tailwindcss(),
     VitePWA({
       registerType: 'autoUpdate',
-      includeAssets: ['favicon.ico', 'apple-touch-icon.png'],
+      includeAssets: ['favicon.svg', 'apple-touch-icon.png'],
       manifest: {
         name: 'The Chaser - Tax Optimizer',
         short_name: 'The Chaser',
@@ -25,19 +25,21 @@ export default defineConfig({
         display: 'standalone',
         icons: [
           {
-            src: '/incometrack/pwa-192x192.png',
+            src: '/incometrack/pwa-192x192.png?v=1',
             sizes: '192x192',
             type: 'image/png',
             purpose: 'any maskable'
           },
           {
-            src: '/incometrack/pwa-512x512.png',
+            src: '/incometrack/pwa-512x512.png?v=1',
             sizes: '512x512',
             type: 'image/png',
             purpose: 'any maskable'
           },
           {
-            src: '/incometrack/apple-touch-icon.png'
+            src: '/incometrack/apple-touch-icon.png?v=1',
+            sizes: '180x180',
+            type: 'image/png'
           }
         ]
       }


### PR DESCRIPTION
Resolves an issue where the Vite React PWA on GitHub Pages displayed a grey placeholder icon on iOS 26 and failed to sync data due to File System Access API writing restrictions. This patch correctly configures PWA manifest assets, cache-busts icons, enforces user-gesture compliance on iOS for database syncing, and appropriately manages storage quota errors.

---
*PR created automatically by Jules for task [15047122340273838740](https://jules.google.com/task/15047122340273838740) started by @John-Bell*