### PR TITLE
Fix settings page back button navigation

### DIFF
--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,4 +1,4 @@
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import { AppLayout } from '../components/layout/AppLayout';
 import { Header } from '../components/layout/Header';
 import { Icon } from '../components/ui/Icon';
@@ -7,12 +7,18 @@ import { HistoryLogItem } from '../components/settings/HistoryLogItem';
 import { archiveCurrentMonth } from '@/services/archiveService';
 
 export function SettingsPage() {
+    const navigate = useNavigate();
+
     return (
         <AppLayout
             header={
                 <Header
                     title="Settings"
-                    leftElement={<Icon name="arrow_back" className="text-primary text-2xl" />}
+                    leftElement={
+                        <button type="button" onClick={() => navigate(-1)} className="flex items-center justify-center cursor-pointer">
+                            <Icon name="arrow_back" className="text-primary text-2xl" />
+                        </button>
+                    }
                     rightElement={<div className="text-xs font-medium bg-primary/10 text-primary px-2 py-1 rounded">V 2.4.0</div>}
                     className="bg-transparent backdrop-blur-md"
                 />


### PR DESCRIPTION
Fixes an issue where the back button on the settings page was a static icon without any click event handlers, preventing users from navigating back to the previous screen. Introduced `useNavigate` from `react-router-dom` to implement correct history traversal.

---
*PR created automatically by Jules for task [18066523104821229080](https://jules.google.com/task/18066523104821229080) started by @John-Bell*