### PR TITLE
feat: update settings to use dynamic tax year dropdown and remove income config

### DIFF
--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,4 +1,6 @@
 import { Link, useNavigate } from 'react-router-dom';
+import { useLiveQuery } from 'dexie-react-hooks';
+import { db } from '../lib/db';
 import { AppLayout } from '../components/layout/AppLayout';
 import { Header } from '../components/layout/Header';
 import { Icon } from '../components/ui/Icon';
@@ -8,6 +10,17 @@ import { archiveCurrentMonth } from '@/services/archiveService';
 
 export function SettingsPage() {
     const navigate = useNavigate();
+
+    const settings = useLiveQuery(() => db.settings.toArray());
+    const taxRules = useLiveQuery(() => db.taxRules.toArray());
+
+    const currentSettings = settings?.[0];
+
+    const handleTaxYearChange = async (e: React.ChangeEvent<HTMLSelectElement>) => {
+        if (currentSettings) {
+            await db.settings.update(currentSettings.id, { taxYear: e.target.value });
+        }
+    };
 
     return (
         <AppLayout
@@ -120,22 +133,19 @@ export function SettingsPage() {
                                 <p className="font-medium">Tax Year</p>
                             </div>
                             <div className="flex items-center gap-2 text-primary font-semibold">
-                                <span>2024/25</span>
-                                <Icon name="chevron_right" className="text-sm" />
+                                <select
+                                    className="bg-transparent text-right text-primary font-semibold appearance-none outline-none cursor-pointer pr-4"
+                                    value={currentSettings?.taxYear || ''}
+                                    onChange={handleTaxYearChange}
+                                >
+                                    {taxRules?.map((rule) => (
+                                        <option key={rule.id} value={rule.id} className="text-slate-900">
+                                            {rule.id}
+                                        </option>
+                                    ))}
+                                </select>
                             </div>
                         </div>
-
-                        <Link to="/income-config" className="flex items-center justify-between p-4 hover:bg-slate-50 dark:hover:bg-primary/10 transition-colors cursor-pointer">
-                            <div className="flex items-center gap-4">
-                                <div className="flex items-center justify-center w-10 h-10 rounded-lg bg-slate-100 dark:bg-primary/5 text-slate-600 dark:text-primary/80">
-                                    <Icon name="tune" />
-                                </div>
-                                <p className="font-medium">Income Configuration</p>
-                            </div>
-                            <div className="flex items-center gap-2 text-primary">
-                                <Icon name="chevron_right" className="text-sm" />
-                            </div>
-                        </Link>
                     </div>
                 </section>
 


### PR DESCRIPTION
This PR addresses the user's request to remove the "Income Configuration" link from the Settings screen and make the "Tax Year" a working dropdown.

Changes:
1.  **Removed Income Configuration:** Removed the entire `Link` component block that navigated to `/income-config`.
2.  **Dynamic Tax Year Dropdown:**
    *   Used `useLiveQuery` to fetch the current `taxRules` and the active `settings` from Dexie.
    *   Replaced the static `<span>` showing "2024/25" with a `<select>` element.
    *   Iterated over the fetched `taxRules` to create `<option>` elements for available tax years.
    *   Implemented an `onChange` handler to update the `taxYear` property in the `settings` database when a new value is selected.
3.  Verified via tests (`npx vitest run`) and Playwright visual testing.

---
*PR created automatically by Jules for task [1220111670308392506](https://jules.google.com/task/1220111670308392506) started by @John-Bell*