### PR TITLE
Fix Income Allocation Percentage Sums

### DIFF
--- a/src/pages/IncomePage.tsx
+++ b/src/pages/IncomePage.tsx
@@ -21,15 +21,15 @@ export function IncomePage() {
 
     const totalRental = p1Incomes.rental + p2Incomes.rental;
     const p1RentalPct = totalRental > 0 ? Math.round((p1Incomes.rental / totalRental) * 100) : 50;
-    const p2RentalPct = totalRental > 0 ? Math.round((p2Incomes.rental / totalRental) * 100) : 50;
+    const p2RentalPct = totalRental > 0 ? 100 - p1RentalPct : 50;
 
     const totalInterest = p1Incomes.interest + p2Incomes.interest;
     const p1InterestPct = totalInterest > 0 ? Math.round((p1Incomes.interest / totalInterest) * 100) : 50;
-    const p2InterestPct = totalInterest > 0 ? Math.round((p2Incomes.interest / totalInterest) * 100) : 50;
+    const p2InterestPct = totalInterest > 0 ? 100 - p1InterestPct : 50;
 
     const totalDividends = p1Incomes.dividends + p2Incomes.dividends;
     const p1DividendsPct = totalDividends > 0 ? Math.round((p1Incomes.dividends / totalDividends) * 100) : 50;
-    const p2DividendsPct = totalDividends > 0 ? Math.round((p2Incomes.dividends / totalDividends) * 100) : 50;
+    const p2DividendsPct = totalDividends > 0 ? 100 - p1DividendsPct : 50;
 
     const formatCurr = (v: number) => `£${v.toLocaleString('en-GB', { maximumFractionDigits: 0 })}`;
     const formatCurrK = (v: number) => `£${(v / 1000).toLocaleString('en-GB', { maximumFractionDigits: 1 })}k`;


### PR DESCRIPTION
Fixed percentage calculations in `IncomePage.tsx` so `p2RentalPct`, `p2InterestPct`, and `p2DividendsPct` sum correctly to 100 with their respective p1 percentages. Previously, rounding the two percentages independently could result in sums of 99% or 101%.

---
*PR created automatically by Jules for task [3869360785057204270](https://jules.google.com/task/3869360785057204270) started by @John-Bell*