### PR TITLE
Update Edit Icons on Budgets and Payments Screens

### DIFF
--- a/src/pages/BudgetsPage.tsx
+++ b/src/pages/BudgetsPage.tsx
@@ -164,7 +164,9 @@ export function BudgetsPage() {
                                                     </div>
                                                 </div>
                                             </div>
-                                            <Icon name="more_vert" className="text-slate-300 dark:text-slate-600 cursor-pointer hover:text-primary transition-colors ml-2" onClick={() => navigate(`/budgets/edit/${budget.id}`)} />
+                                            <div className="flex items-center justify-center w-8 h-8 rounded-full bg-slate-100 dark:bg-slate-800 ml-2 cursor-pointer hover:bg-slate-200 dark:hover:bg-slate-700 transition-colors flex-shrink-0" onClick={() => navigate(`/budgets/edit/${budget.id}`)}>
+                                                <Icon name="edit" className="text-[18px] text-slate-500 dark:text-slate-400" />
+                                            </div>
                                         </div>
 
                                         <div>

--- a/src/pages/TransactionsPage.tsx
+++ b/src/pages/TransactionsPage.tsx
@@ -67,7 +67,7 @@ export function TransactionsPage() {
                         </div>
                         <div className="space-y-1">
                             {dailyTransactions.map((tx) => (
-                                <Link to={`/transactions/edit/${tx.id}`} key={tx.id} className="flex items-center gap-4 py-4 hover:bg-primary/5 transition-colors cursor-pointer border-b border-slate-100 dark:border-primary/5">
+                                <Link to={`/transactions/edit/${tx.id}`} key={tx.id} className="group flex items-center gap-4 py-4 hover:bg-primary/5 transition-colors cursor-pointer border-b border-slate-100 dark:border-primary/5">
                                     <div className="size-12 min-w-[3rem] rounded-xl bg-primary/10 flex items-center justify-center text-primary">
                                         <Icon name={tx.icon} />
                                     </div>
@@ -76,12 +76,14 @@ export function TransactionsPage() {
                                             <div className="flex items-center gap-2 overflow-hidden">
                                                 <h3 className="font-bold text-slate-900 dark:text-slate-100 truncate">{tx.payee}</h3>
                                             </div>
-                                            <div className="flex items-center gap-2">
+                                            <div className="flex items-center gap-3">
                                                 <span className={`font-bold ${tx.type === 'expense' ? 'text-rose-500 dark:text-rose-400' : 'text-primary'}`}>
                                                     {tx.type === 'expense' ? '-' : '+'}
                                                     {new Intl.NumberFormat('en-GB', { style: 'currency', currency: 'GBP', minimumFractionDigits: 2 }).format(tx.amount)}
                                                 </span>
-                                                <Icon name="chevron_right" className="text-slate-400 dark:text-slate-500 text-lg" />
+                                                <div className="flex items-center justify-center w-8 h-8 rounded-full bg-slate-100 dark:bg-slate-800 transition-colors flex-shrink-0 group-hover:bg-slate-200 dark:group-hover:bg-slate-700">
+                                                    <Icon name="edit" className="text-[18px] text-slate-500 dark:text-slate-400" />
+                                                </div>
                                             </div>
                                         </div>
                                         <div className="flex justify-between items-center mt-0.5">


### PR DESCRIPTION
Updated the edit links on both the Budgets and Payments (Transactions) screens. The existing 3-dots (`more_vert`) and chevron (`chevron_right`) icons have been replaced with a pencil (`edit`) icon. To improve the user experience and match the provided screenshot, the icons are now wrapped in a subtle circular background that responds to hover events. Tests and build step passed successfully, and Playwright verification scripts confirmed the visual changes match the expectations.

---
*PR created automatically by Jules for task [8587797027170086501](https://jules.google.com/task/8587797027170086501) started by @John-Bell*