### PR TITLE
Fix category display on payment screens

### DIFF
--- a/src/pages/AddPaymentPage.tsx
+++ b/src/pages/AddPaymentPage.tsx
@@ -10,6 +10,8 @@ export function AddPaymentPage() {
     const navigate = useNavigate();
 
     const budgets = useLiveQuery(() => db.budgets.toArray()) || [];
+    const budgetCategories = useLiveQuery(() => db.budgetCategories.toArray()) || [];
+    const categoryNameMap = Object.fromEntries(budgetCategories.map(c => [c.id, c.name]));
 
     const [payee, setPayee] = useState('');
     const [amount, setAmount] = useState('');
@@ -130,9 +132,11 @@ export function AddPaymentPage() {
                                 className="w-full bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl px-4 py-3 text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary transition-colors appearance-none"
                             >
                                 <option value="" disabled>Select a category</option>
-                                {Array.from(new Set(budgets.map(b => b.category))).sort().map(cat => (
-                                    <option key={cat} value={cat}>{cat}</option>
-                                ))}
+                                {Array.from(new Set(budgets.map(b => b.category)))
+                                    .sort((a, b) => (categoryNameMap[a] || a).localeCompare(categoryNameMap[b] || b))
+                                    .map(catId => (
+                                        <option key={catId} value={catId}>{categoryNameMap[catId] || catId}</option>
+                                    ))}
                             </select>
                             <div className="absolute inset-y-0 right-0 flex items-center pr-4 pointer-events-none text-slate-400">
                                 <span className="material-symbols-outlined">expand_more</span>

--- a/src/pages/EditPaymentPage.tsx
+++ b/src/pages/EditPaymentPage.tsx
@@ -11,6 +11,8 @@ export function EditPaymentPage() {
 
     const transaction = useLiveQuery(() => db.transactions.get(id as string));
     const budgets = useLiveQuery(() => db.budgets.toArray()) || [];
+    const budgetCategories = useLiveQuery(() => db.budgetCategories.toArray()) || [];
+    const categoryNameMap = Object.fromEntries(budgetCategories.map(c => [c.id, c.name]));
 
     const [payee, setPayee] = useState('');
     const [amount, setAmount] = useState('');
@@ -158,9 +160,11 @@ export function EditPaymentPage() {
                                 className="w-full bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl px-4 py-3 text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary transition-colors appearance-none"
                             >
                                 <option value="" disabled>Select a category</option>
-                                {Array.from(new Set(budgets.map(b => b.category))).sort().map(cat => (
-                                    <option key={cat} value={cat}>{cat}</option>
-                                ))}
+                                {Array.from(new Set(budgets.map(b => b.category)))
+                                    .sort((a, b) => (categoryNameMap[a] || a).localeCompare(categoryNameMap[b] || b))
+                                    .map(catId => (
+                                        <option key={catId} value={catId}>{categoryNameMap[catId] || catId}</option>
+                                    ))}
                             </select>
                             <div className="absolute inset-y-0 right-0 flex items-center pr-4 pointer-events-none text-slate-400">
                                 <span className="material-symbols-outlined">expand_more</span>


### PR DESCRIPTION
The category dropdowns on the "Add Payment" and "Edit Payment" screens were previously displaying the internal database IDs (UUIDs) for the budget categories instead of their human-readable names. This PR fixes the issue by querying the `budgetCategories` Dexie table, creating a lookup map, and displaying the resolved names in the dropdown while maintaining the ID as the underlying select value. Options are now correctly sorted alphabetically by name.

---
*PR created automatically by Jules for task [15171250871223783397](https://jules.google.com/task/15171250871223783397) started by @John-Bell*