### PR TITLE
Refactor transactions to use budgetId instead of category strings

### DIFF
--- a/src/components/dashboard/TopExpenses.tsx
+++ b/src/components/dashboard/TopExpenses.tsx
@@ -1,3 +1,5 @@
+import { useLiveQuery } from 'dexie-react-hooks';
+import { db } from '@/lib/db';
 import { Icon } from '../ui/Icon';
 import type { Transaction } from '@/lib/db';
 
@@ -7,6 +9,11 @@ interface TopExpensesProps {
 }
 
 export function TopExpenses({ expenses }: TopExpensesProps) {
+    const budgets = useLiveQuery(() => db.budgets.toArray()) || [];
+    const budgetCategories = useLiveQuery(() => db.budgetCategories.toArray()) || [];
+    const budgetsMap = Object.fromEntries(budgets.map(b => [b.id, b]));
+    const categoriesMap = Object.fromEntries(budgetCategories.map(c => [c.id, c.name]));
+
     if (!expenses || expenses.length === 0) {
         return null; 
     }
@@ -30,6 +37,7 @@ export function TopExpenses({ expenses }: TopExpensesProps) {
                                 </div>
                                 <div className="min-w-0">
                                     <p className="font-semibold text-sm text-slate-900 dark:text-slate-100 truncate">{expense.payee}</p>
+                                    <p className="text-xs text-slate-500 capitalize">{expense.budgetId ? (categoriesMap[budgetsMap[expense.budgetId]?.budgetCategoryId] || budgetsMap[expense.budgetId]?.budgetCategoryId || 'Uncategorized') : 'Uncategorized'}</p>
                                 </div>
                             </div>
                             <div className="text-right flex-shrink-0 pl-2">

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -119,7 +119,7 @@ export interface BudgetCategory {
 
 export interface Budget {
     id: string;
-    category: string;
+    budgetCategoryId: string;
     name: string; // sub-category
     amount: number;
     frequency: string; // e.g. monthly, annual
@@ -164,14 +164,25 @@ db.version(2).stores({
     budgetCategories: '&id, name, updatedAt'
 });
 
-// Schema version 3 - Removes category/subCategory from transactions
+// Schema version 3 - Removes category/subCategory from transactions and renames category to budgetCategoryId on budgets
 db.version(3).stores({
-    transactions: '&id, date, type, budgetId, importId, updatedAt'
+    profile: '&id',
+    accounts: '&id, ownerId, name, category, importId, updatedAt',
+    incomes: '&id, ownerId, name, frequency, type, taxCategory, updatedAt',
+    scenarios: '&id, name, updatedAt',
+    settings: '&id',
+    monthlyArchives: '&id, month, year, updatedAt',
+    notifications: '&id, date, read, updatedAt',
+    taxRules: '&id, updatedAt',
+    budgets: '&id, budgetCategoryId, name, importId, updatedAt',
+    transactions: '&id, date, type, budgetId, importId, updatedAt',
+    budgetCategories: '&id, name, updatedAt'
 }).upgrade(async tx => {
     // We need to fetch budgets using raw Dexie transaction table since types might not fully match during upgrade
     const budgets = await tx.table('budgets').toArray();
 
-    return tx.table('transactions').toCollection().modify(transaction => {
+    // Migrate Transactions
+    await tx.table('transactions').toCollection().modify(transaction => {
         // Only migrate if we have the old fields
         if (transaction.category) {
             // If it doesn't already have a budgetId, try to find one
@@ -189,6 +200,15 @@ db.version(3).stores({
             // Remove old fields
             delete transaction.category;
             delete transaction.subCategory;
+        }
+    });
+
+    // Migrate Budgets
+    await tx.table('budgets').toCollection().modify(budget => {
+        // Only migrate if we have the old field
+        if (budget.category) {
+            budget.budgetCategoryId = budget.category;
+            delete budget.category;
         }
     });
 });

--- a/src/pages/AddBudgetPage.tsx
+++ b/src/pages/AddBudgetPage.tsx
@@ -20,7 +20,7 @@ export function AddBudgetPage() {
 
         await db.budgets.add({
             id: crypto.randomUUID(),
-            category,
+            budgetCategoryId: category,
             name,
             amount: parseFloat(amount) || 0,
             frequency,

--- a/src/pages/AddPaymentPage.tsx
+++ b/src/pages/AddPaymentPage.tsx
@@ -124,7 +124,7 @@ export function AddPaymentPage() {
                                 className="w-full bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl px-4 py-3 text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary transition-colors appearance-none"
                             >
                                 <option value="" disabled>Select a category</option>
-                                {Array.from(new Set(budgets.map(b => b.category)))
+                                {Array.from(new Set(budgets.map(b => b.budgetCategoryId)))
                                     .sort((a, b) => (categoryNameMap[a] || a).localeCompare(categoryNameMap[b] || b))
                                     .map(catId => (
                                         <option key={catId} value={catId}>{categoryNameMap[catId] || catId}</option>
@@ -148,7 +148,7 @@ export function AddPaymentPage() {
                             >
                                 <option value="" disabled>Select a sub-category</option>
                                 {budgets
-                                    .filter(b => b.category === category)
+                                    .filter(b => b.budgetCategoryId === category)
                                     .sort((a, b) => a.name.localeCompare(b.name))
                                     .map(budget => (
                                         <option key={budget.id} value={budget.id}>{budget.name}</option>

--- a/src/pages/BudgetsPage.tsx
+++ b/src/pages/BudgetsPage.tsx
@@ -18,10 +18,10 @@ export function BudgetsPage() {
 
     // Group budgets by category
     const groupedBudgets = budgets.reduce((acc, budget) => {
-        if (!acc[budget.category]) {
-            acc[budget.category] = [];
+        if (!acc[budget.budgetCategoryId]) {
+            acc[budget.budgetCategoryId] = [];
         }
-        acc[budget.category].push(budget);
+        acc[budget.budgetCategoryId].push(budget);
         return acc;
     }, {} as Record<string, typeof budgets>);
 

--- a/src/pages/EditBudgetPage.tsx
+++ b/src/pages/EditBudgetPage.tsx
@@ -21,7 +21,7 @@ export function EditBudgetPage() {
 
     useEffect(() => {
         if (budget) {
-            setCategory(budget.category);
+            setCategory(budget.budgetCategoryId);
             setName(budget.name);
             setAmount(budget.amount.toString());
             setFrequency(budget.frequency);
@@ -33,7 +33,7 @@ export function EditBudgetPage() {
         if (!id || !budget) return;
 
         await db.budgets.update(id, {
-            category,
+            budgetCategoryId: category,
             name,
             amount: parseFloat(amount) || 0,
             frequency,

--- a/src/pages/EditPaymentPage.tsx
+++ b/src/pages/EditPaymentPage.tsx
@@ -29,7 +29,7 @@ export function EditPaymentPage() {
             if (transaction.budgetId && budgets) {
                 const budget = budgets.find(b => b.id === transaction.budgetId);
                 if (budget) {
-                    setCategory(budget.category);
+                    setCategory(budget.budgetCategoryId);
                 }
             }
 
@@ -159,7 +159,7 @@ export function EditPaymentPage() {
                                 className="w-full bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl px-4 py-3 text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary transition-colors appearance-none"
                             >
                                 <option value="" disabled>Select a category</option>
-                                {Array.from(new Set(budgets.map(b => b.category)))
+                                {Array.from(new Set(budgets.map(b => b.budgetCategoryId)))
                                     .sort((a, b) => (categoryNameMap[a] || a).localeCompare(categoryNameMap[b] || b))
                                     .map(catId => (
                                         <option key={catId} value={catId}>{categoryNameMap[catId] || catId}</option>
@@ -183,7 +183,7 @@ export function EditPaymentPage() {
                             >
                                 <option value="" disabled>Select a sub-category</option>
                                 {budgets
-                                    .filter(b => b.category === category)
+                                    .filter(b => b.budgetCategoryId === category)
                                     .sort((a, b) => a.name.localeCompare(b.name))
                                     .map(budget => (
                                         <option key={budget.id} value={budget.id}>{budget.name}</option>

--- a/src/pages/ImportProcessor.tsx
+++ b/src/pages/ImportProcessor.tsx
@@ -7,7 +7,7 @@ import { DataImportService } from '../services/DataImportService';
 
 const TABLE_SCHEMAS: Record<string, string[]> = {
     accounts: ['id', 'name', 'balance', 'interestRate', 'category', 'ownerId', 'notes'],
-    budgets: ['id', 'category', 'name', 'amount', 'frequency', 'paymentSource', 'ownership', 'importMappingName'],
+    budgets: ['id', 'importCategory', 'name', 'amount', 'frequency', 'paymentSource', 'ownership', 'importMappingName'],
     transactions: ['id', 'date', 'payee', 'amount', 'importCategory', 'type', 'icon', 'rawDesc']
 };
 

--- a/src/pages/TransactionsPage.tsx
+++ b/src/pages/TransactionsPage.tsx
@@ -92,7 +92,7 @@ export function TransactionsPage() {
                                             </div>
                                         </div>
                                         <div className="flex justify-between items-center mt-0.5">
-                                            <p className="text-sm text-slate-500 dark:text-slate-400 truncate">{tx.budgetId ? (categoriesMap[budgetsMap[tx.budgetId]?.category] || budgetsMap[tx.budgetId]?.category || 'Uncategorized') : 'Uncategorized'}</p>
+                                            <p className="text-sm text-slate-500 dark:text-slate-400 truncate">{tx.budgetId ? (categoriesMap[budgetsMap[tx.budgetId]?.budgetCategoryId] || budgetsMap[tx.budgetId]?.budgetCategoryId || 'Uncategorized') : 'Uncategorized'}</p>
                                             <span className="text-[10px] font-bold px-2 py-0.5 rounded-full bg-blue-500/20 text-blue-400 uppercase">{tx.budgetId ? (budgetsMap[tx.budgetId]?.name || 'Unknown') : 'Unknown'}</span>
                                         </div>
                                     </div>

--- a/src/services/DataImportService.test.ts
+++ b/src/services/DataImportService.test.ts
@@ -19,9 +19,9 @@ describe('DataImportService', () => {
         });
 
         it('should generate deterministic ID for budgets', () => {
-            const row1 = { category: 'Food', name: 'Groceries', amount: '500' };
-            const row2 = { category: 'Food', name: 'Groceries', amount: '500' };
-            const row3 = { category: 'Food', name: 'Dining Out', amount: '500' };
+            const row1 = { importCategory: 'Food', name: 'Groceries', amount: '500' };
+            const row2 = { importCategory: 'Food', name: 'Groceries', amount: '500' };
+            const row3 = { importCategory: 'Food', name: 'Dining Out', amount: '500' };
 
             const id1 = DataImportService.generateDeterministicId(row1, 'budgets');
             const id2 = DataImportService.generateDeterministicId(row2, 'budgets');
@@ -125,7 +125,7 @@ describe('DataImportService', () => {
             await db.budgets.add({
                 id: budgetId,
                 name: 'Groceries',
-                category: 'Food',
+                budgetCategoryId: 'Food',
                 amount: 500,
                 frequency: 'monthly',
                 paymentSource: 'Monthly Bills',
@@ -169,7 +169,7 @@ describe('DataImportService', () => {
             const data = [
                 { category: 'Utilities', name: 'Water', amount: '50' }
             ];
-            const mapping = { category: 'category', name: 'name', amount: 'amount' };
+            const mapping = { category: 'importCategory', name: 'name', amount: 'amount' };
 
             const result = await DataImportService.importData('budgets', data, 'import-file-2', mapping);
             expect(result).toBe(1);
@@ -181,7 +181,13 @@ describe('DataImportService', () => {
             expect(b.amount).toBe(50); // parsed correctly
             expect(b.frequency).toBe('monthly');
             expect(b.paymentSource).toBe('Monthly Bills');
+            expect(b.budgetCategoryId).toBe('utilities'); // derived category ID
+            expect((b as any).importCategory).toBeUndefined();
             expect(b.importId).toBe('import-file-2');
+
+            // Should have created a budget category
+            const categories = await db.budgetCategories.toArray();
+            expect(categories).toContainEqual(expect.objectContaining({ id: 'utilities', name: 'Utilities' }));
         });
 
         it('should assign default values when importing accounts', async () => {

--- a/src/services/DataImportService.ts
+++ b/src/services/DataImportService.ts
@@ -44,7 +44,7 @@ export class DataImportService {
         if (targetTable === 'transactions') {
             sourceString = `${row.date || ''}-${row.amount || ''}-${row.payee || ''}-${row.rawDesc || ''}-${row.importCategory || ''}`;
         } else if (targetTable === 'budgets') {
-            sourceString = `${row.category || ''}-${row.name || ''}-${row.amount || ''}`;
+            sourceString = `${row.importCategory || ''}-${row.name || ''}-${row.amount || ''}`;
         } else if (targetTable === 'accounts') {
             sourceString = `${row.name || ''}-${row.category || ''}-${row.ownerId || ''}`;
         } else {
@@ -76,6 +76,12 @@ export class DataImportService {
         let budgets: Budget[] = [];
         if (targetTable === 'transactions') {
             budgets = await db.budgets.toArray();
+        }
+
+        // Pre-fetch budgetCategories if we are importing budgets
+        let budgetCategories: {id: string, name: string}[] = [];
+        if (targetTable === 'budgets') {
+            budgetCategories = await db.budgetCategories.toArray();
         }
 
         for (const row of data) {
@@ -119,7 +125,7 @@ export class DataImportService {
                     const matchedBudget = budgets.find(b =>
                         (b.importMappingName && b.importMappingName.toLowerCase() === categoryLower) ||
                         (b.name && b.name.toLowerCase() === categoryLower) ||
-                        (b.category && b.category.toLowerCase() === categoryLower)
+                        (b.budgetCategoryId && b.budgetCategoryId.toLowerCase() === categoryLower)
                     );
 
                     if (matchedBudget) {
@@ -132,6 +138,36 @@ export class DataImportService {
             } else if (targetTable === 'budgets') {
                 if (!mappedRow.frequency) mappedRow.frequency = 'monthly';
                 if (!mappedRow.paymentSource) mappedRow.paymentSource = 'Monthly Bills';
+
+                // Map the incoming category string to a budgetCategoryId
+                if (mappedRow.importCategory && !mappedRow.budgetCategoryId) {
+                    const categoryLower = mappedRow.importCategory.toLowerCase();
+                    const matchedCategory = budgetCategories.find(c => c.name.toLowerCase() === categoryLower);
+
+                    if (matchedCategory) {
+                        mappedRow.budgetCategoryId = matchedCategory.id;
+                    } else {
+                        // Create a new budget category if it doesn't exist
+                        const newCategoryId = mappedRow.importCategory.toLowerCase().replace(/[^a-z0-9]/g, '-');
+
+                        // We check if it exists in the array again to avoid duplicates in the same batch
+                        const existingInBatch = budgetCategories.find(c => c.id === newCategoryId);
+                        if (!existingInBatch) {
+                            budgetCategories.push({ id: newCategoryId, name: mappedRow.importCategory });
+                            // Wait for it to be created in DB
+                            await db.budgetCategories.put({
+                                id: newCategoryId,
+                                name: mappedRow.importCategory,
+                                updatedAt: now
+                            });
+                        }
+
+                        mappedRow.budgetCategoryId = newCategoryId;
+                    }
+                }
+
+                // Cleanup temporary mapping field
+                delete mappedRow.importCategory;
             } else if (targetTable === 'accounts') {
                 if (!mappedRow.ownerId) mappedRow.ownerId = 'default';
                 if (mappedRow.balance === undefined) mappedRow.balance = 0;


### PR DESCRIPTION
The user requested removing the `category` and `subcategory` fields from the `transactions` table, opting instead to link solely via `budgetId`. Additionally, the Add/Edit payment pages were updated so that the "Category" dropdown now merely acts as a filter for the resulting "Sub-category" (Budget) dropdown.

1. **Schema Update:** Removed `category` and `subCategory` from the `Transaction` interface. Maintained `db.version(1)` and `db.version(2)` schemas to ensure stability. Added `db.version(3)` to automatically drop the `category` index and introduced an `upgrade` function that iterates through all existing transactions. It matches legacy categories to budgets, assigns the `budgetId`, and cleans up the deprecated properties.
2. **Payment Forms:** Updated `AddPaymentPage` and `EditPaymentPage` state management to only store `budgetId` upon save. Introduced a non-persistent `category` state strictly for filtering the budget select dropdown visually.
3. **Transaction Feed:** Updated `TransactionsPage` to resolve the category and budget names dynamically by looking up the `budgetId` against mapped collections of budgets and budget categories. Updated `TopExpenses` dashboard widget to reflect the schema change.
4. **Data Import Processing:** Refactored `ImportProcessor.tsx` and `DataImportService.ts` to assign incoming categories from CSV/JSON to a temporary `importCategory` property. This property is used internally to link transactions to a `budgetId`, after which it is deleted before the bulk database upsert. Tested with Vitest.

---
*PR created automatically by Jules for task [12543216548447918402](https://jules.google.com/task/12543216548447918402) started by @John-Bell*