### PR TITLE
fix: resolve swift decoding mismatch on remote sync and sync missing tables

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -198,6 +198,57 @@ db.version(3).stores({
     paymentMappings: '&id, paymentName, *budgetIds, updatedAt'
 });
 
+export const getSanitizedDbData = async (): Promise<Record<string, any[]>> => {
+    const rawData = {
+        profile: await db.profile.toArray(),
+        accounts: await db.accounts.toArray(),
+        incomes: await db.incomes.toArray(),
+        scenarios: await db.scenarios.toArray(),
+        settings: await db.settings.toArray(),
+        monthlyArchives: await db.monthlyArchives.toArray(),
+        notifications: await db.notifications.toArray(),
+        taxRules: await db.taxRules.toArray(),
+        transactions: await db.transactions.toArray(),
+        budgets: await db.budgets.toArray(),
+        budgetCategories: await db.budgetCategories.toArray(),
+        paymentMappings: await db.paymentMappings.toArray(),
+    };
+
+    // Sanitize common numeric fields that might have accidentally been saved as strings,
+    // which breaks strictly-typed Swift Decodable models in the iOS app.
+    if (rawData.transactions) {
+        rawData.transactions = rawData.transactions.map(t => ({
+            ...t,
+            amount: Number(t.amount) || 0,
+            date: Number(t.date) || 0,
+        }));
+    }
+
+    if (rawData.budgets) {
+        rawData.budgets = rawData.budgets.map(b => ({
+            ...b,
+            amount: Number(b.amount) || 0,
+        }));
+    }
+
+    if (rawData.accounts) {
+        rawData.accounts = rawData.accounts.map(a => ({
+            ...a,
+            balance: Number(a.balance) || 0,
+            interestRate: Number(a.interestRate) || 0,
+        }));
+    }
+
+    if (rawData.incomes) {
+        rawData.incomes = rawData.incomes.map(i => ({
+            ...i,
+            amount: Number(i.amount) || 0,
+        }));
+    }
+
+    return rawData;
+};
+
 export const initDb = async () => {
     try {
         await db.open();

--- a/src/pages/RemoteSyncingPage.tsx
+++ b/src/pages/RemoteSyncingPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useLiveQuery } from 'dexie-react-hooks';
-import { db } from '@/lib/db';
+import { db, getSanitizedDbData } from '@/lib/db';
 import { AppLayout } from '@/components/layout/AppLayout';
 import { Header } from '@/components/layout/Header';
 import { Icon } from '@/components/ui/Icon';
@@ -111,19 +111,8 @@ export function RemoteSyncingPage() {
         setIsProcessing(true);
         setStatusMessage(null);
         try {
-            // Extract full database
-            const allData: Record<string, any[]> = {
-                profile: await db.profile.toArray(),
-                accounts: await db.accounts.toArray(),
-                incomes: await db.incomes.toArray(),
-                scenarios: await db.scenarios.toArray(),
-                settings: await db.settings.toArray(),
-                monthlyArchives: await db.monthlyArchives.toArray(),
-                notifications: await db.notifications.toArray(),
-                taxRules: await db.taxRules.toArray(),
-                transactions: await db.transactions.toArray(),
-                budgets: await db.budgets.toArray(),
-            };
+            // Extract full database, ensuring numeric sanitization
+            const allData = await getSanitizedDbData();
 
             // Encrypt
             const encryptedBlob = await encryptData(allData, syncPassphrase.trim());

--- a/src/services/backupService.ts
+++ b/src/services/backupService.ts
@@ -1,4 +1,4 @@
-import { db } from '@/lib/db';
+import { db, getSanitizedDbData } from '@/lib/db';
 
 export interface BackupData {
     version: number;
@@ -9,18 +9,7 @@ export const exportDatabase = async () => {
     try {
         const backup: BackupData = {
             version: 1,
-            data: {
-                profile: await db.profile.toArray(),
-                accounts: await db.accounts.toArray(),
-                incomes: await db.incomes.toArray(),
-                scenarios: await db.scenarios.toArray(),
-                settings: await db.settings.toArray(),
-                monthlyArchives: await db.monthlyArchives.toArray(),
-                notifications: await db.notifications.toArray(),
-                taxRules: await db.taxRules.toArray(),
-                transactions: await db.transactions.toArray(),
-                budgets: await db.budgets.toArray(),
-            }
+            data: await getSanitizedDbData()
         };
 
         // Remove cloudHandle from settings before stringifying to avoid serialization issues
@@ -100,7 +89,8 @@ export const importDatabase = async () => {
 
         const tables = [
             'profile', 'accounts', 'incomes', 'scenarios', 'settings',
-            'monthlyArchives', 'notifications', 'taxRules', 'transactions', 'budgets'
+            'monthlyArchives', 'notifications', 'taxRules', 'transactions', 'budgets',
+            'budgetCategories', 'paymentMappings'
         ];
         const dexieTables = tables.map(t => (db as any)[t]);
 

--- a/src/services/remoteSyncService.ts
+++ b/src/services/remoteSyncService.ts
@@ -34,9 +34,9 @@ async function deriveKey(passphrase: string, salt: Uint8Array): Promise<CryptoKe
 
 export async function mergeData(cloudData: Record<string, any[]>): Promise<boolean> {
     let hasLocalChanges = false;
-    const tables = ['profile', 'accounts', 'incomes', 'scenarios', 'settings', 'monthlyArchives', 'notifications', 'taxRules', 'transactions', 'budgets'];
+    const tables = ['profile', 'accounts', 'incomes', 'scenarios', 'settings', 'monthlyArchives', 'notifications', 'taxRules', 'transactions', 'budgets', 'budgetCategories', 'paymentMappings'];
 
-    const tableList = [db.profile, db.accounts, db.incomes, db.scenarios, db.settings, db.monthlyArchives, db.notifications, db.taxRules, db.transactions, db.budgets];
+    const tableList = [db.profile, db.accounts, db.incomes, db.scenarios, db.settings, db.monthlyArchives, db.notifications, db.taxRules, db.transactions, db.budgets, db.budgetCategories, db.paymentMappings];
 
     dbHooks.isSyncing = true;
     await db.transaction('rw', tableList, async () => {
@@ -230,19 +230,9 @@ export const remoteSyncService = {
 
             // 3. Extract full database and 4. Encrypt & Push (If Needed)
             if (hasLocalChanges || serverLastUpdated === 0) {
-                // 3. Extract full database
-                const allData: Record<string, any[]> = {
-                    profile: await db.profile.toArray(),
-                    accounts: await db.accounts.toArray(),
-                    incomes: await db.incomes.toArray(),
-                    scenarios: await db.scenarios.toArray(),
-                    settings: await db.settings.toArray(),
-                    monthlyArchives: await db.monthlyArchives.toArray(),
-                    notifications: await db.notifications.toArray(),
-                    taxRules: await db.taxRules.toArray(),
-                    transactions: await db.transactions.toArray(),
-                    budgets: await db.budgets.toArray(),
-                };
+                // 3. Extract full database, including numeric sanitization for strict clients
+                const { getSanitizedDbData } = await import('@/lib/db');
+                const allData = await getSanitizedDbData();
 
                 // 4. Encrypt & Push
                 const encryptedBlob = await encryptData(allData, syncPassphrase);


### PR DESCRIPTION
Fixes the iOS app parsing crash (`DecodingError.typeMismatch`) that occurred when syncing data from remote or during the initial setup stages.

The issue was caused by specific numeric properties (`amount`, `date`, `balance`, `interestRate`) being inadvertently saved as strings into the Dexie DB (e.g. from input fields) and directly serialized to JSON during `remoteSyncService` or `backupService` operations. Strictly typed clients (like Swift) failed to decode these string values. 

The fix consolidates the DB table extraction into a `getSanitizedDbData()` helper function that strictly casts these numeric properties to JS Numbers before payload generation. In addition, the tables list in `mergeData` and `backupService` imports were updated to correctly include the recently added `budgetCategories` and `paymentMappings` tables so they are not skipped during remote restore and sync processes.

---
*PR created automatically by Jules for task [6393530091184640330](https://jules.google.com/task/6393530091184640330) started by @John-Bell*