### PR TITLE
Add optional budgetOrder field to Accounts

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -25,6 +25,7 @@ export interface Account {
     category: string; // e.g., 'Cash', 'Investments', 'Pensions'
     nickname?: string;
     last4Digits?: string;
+    budgetOrder?: number;
     // --- Bonus Rate Fields ---
     bonusRateActive?: boolean;
     bonusEndDate?: number; // timestamp
@@ -245,6 +246,7 @@ export const getSanitizedDbData = async (): Promise<Record<string, any[]>> => {
             ...a,
             balance: Number(a.balance) || 0,
             interestRate: Number(a.interestRate) || 0,
+            budgetOrder: a.budgetOrder !== undefined ? Number(a.budgetOrder) : undefined,
         }));
     }
 

--- a/src/pages/AddAccountPage.tsx
+++ b/src/pages/AddAccountPage.tsx
@@ -17,6 +17,7 @@ export function AddAccountPage() {
     const [category, setCategory] = useState<AccountCategory | ''>('');
     const [balance, setBalance] = useState('');
     const [interestRate, setInterestRate] = useState('');
+    const [budgetOrder, setBudgetOrder] = useState('');
     const [bonusRateActive, setBonusRateActive] = useState(false);
     const [bonusEndDate, setBonusEndDate] = useState('');
     const [ownerId, setOwnerId] = useState('joint'); // 'person1', 'person2', 'joint'
@@ -39,6 +40,7 @@ export function AddAccountPage() {
             balance: parseFloat(balance),
             interestRate: finalInterestRate,
             category,
+            budgetOrder: budgetOrder !== '' ? parseInt(budgetOrder, 10) : undefined,
             bonusRateActive: showBonus ? bonusRateActive : false,
             // Convert 'YYYY-MM-DD' back to timestamp if active, else undefined
             bonusEndDate: showBonus && bonusRateActive && bonusEndDate ? new Date(bonusEndDate).getTime() : undefined,
@@ -121,6 +123,18 @@ export function AddAccountPage() {
                         </select>
                         <span className="absolute right-4 top-1/2 -translate-y-1/2 material-symbols-outlined pointer-events-none text-slate-400">expand_more</span>
                     </div>
+                </div>
+
+                {/* Budget Order Field */}
+                <div className="space-y-2">
+                    <label className="block text-sm font-semibold text-slate-600 dark:text-slate-400">Budget Order (Optional)</label>
+                    <input
+                        className="w-full h-14 px-4 rounded-lg bg-white dark:bg-primary/5 border border-slate-200 dark:border-primary/20 focus:border-primary focus:ring-1 focus:ring-primary outline-none transition-all text-slate-900 dark:text-slate-100"
+                        type="number"
+                        placeholder="e.g. 1"
+                        value={budgetOrder}
+                        onChange={(e) => setBudgetOrder(e.target.value)}
+                    />
                 </div>
 
                 {/* Balance Field */}

--- a/src/pages/EditAccountPage.tsx
+++ b/src/pages/EditAccountPage.tsx
@@ -21,6 +21,7 @@ export function EditAccountPage() {
     const [category, setCategory] = useState<AccountCategory | ''>('');
     const [balance, setBalance] = useState('');
     const [interestRate, setInterestRate] = useState('');
+    const [budgetOrder, setBudgetOrder] = useState('');
     const [bonusRateActive, setBonusRateActive] = useState(false);
     const [bonusEndDate, setBonusEndDate] = useState('');
     const [ownerId, setOwnerId] = useState('joint');
@@ -35,6 +36,7 @@ export function EditAccountPage() {
             setCategory((account.category as AccountCategory) || '');
             setBalance(account.balance.toString());
             setInterestRate(account.interestRate.toString());
+            setBudgetOrder(account.budgetOrder !== undefined ? account.budgetOrder.toString() : '');
             setBonusRateActive(account.bonusRateActive || false);
             if (account.bonusEndDate) {
                 // Convert timestamp to YYYY-MM-DD
@@ -65,6 +67,7 @@ export function EditAccountPage() {
                 category,
                 balance: parseFloat(balance),
                 interestRate: finalInterestRate,
+                budgetOrder: budgetOrder !== '' ? parseInt(budgetOrder, 10) : undefined,
                 bonusRateActive: showBonus ? bonusRateActive : false,
                 bonusEndDate: showBonus && bonusRateActive && bonusEndDate ? new Date(bonusEndDate).getTime() : undefined,
                 ownerId,
@@ -155,6 +158,18 @@ export function EditAccountPage() {
                         </select>
                         <span className="absolute right-4 top-1/2 -translate-y-1/2 material-symbols-outlined pointer-events-none text-slate-400">expand_more</span>
                     </div>
+                </div>
+
+                {/* Budget Order Field */}
+                <div className="space-y-2">
+                    <label className="block text-sm font-semibold text-slate-600 dark:text-slate-400">Budget Order (Optional)</label>
+                    <input
+                        className="w-full h-14 px-4 rounded-lg bg-white dark:bg-primary/5 border border-slate-200 dark:border-primary/20 focus:border-primary focus:ring-1 focus:ring-primary outline-none transition-all text-slate-900 dark:text-slate-100"
+                        type="number"
+                        placeholder="e.g. 1"
+                        value={budgetOrder}
+                        onChange={(e) => setBudgetOrder(e.target.value)}
+                    />
                 </div>
 
                 {/* Balance Field */}


### PR DESCRIPTION
This PR adds an optional numeric field `budgetOrder` to the `accounts` table in the database and the UI.
- Updated `Account` interface in `src/lib/db.ts` to include `budgetOrder?: number;`.
- Sanitized `budgetOrder` during DB exports to strictly type as Number if present.
- Updated `AddAccountPage.tsx` to include an input for `budgetOrder` with type number, saving correctly.
- Updated `EditAccountPage.tsx` to include the same input and pre-fill its current value if available.
- Wrote Playwright scripts to visually confirm the new fields correctly appear and take input on both pages.
- Tested and verified the changes passing all unit tests.

---
*PR created automatically by Jules for task [4910228820163603817](https://jules.google.com/task/4910228820163603817) started by @John-Bell*