### PR TITLE
Fix account dropdowns and budget order visibility

### DIFF
--- a/src/pages/AddAccountPage.tsx
+++ b/src/pages/AddAccountPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { db } from '@/lib/db';
 import { useStore } from '@/store/useStore';
@@ -15,6 +15,13 @@ export function AddAccountPage() {
     const [nickname, setNickname] = useState('');
     const [last4Digits, setLast4Digits] = useState('');
     const [category, setCategory] = useState<AccountCategory | ''>('');
+
+    // Effect to clear budget order when category is not 'Current Account'
+    useEffect(() => {
+        if (category !== 'Current Account') {
+            setBudgetOrder('');
+        }
+    }, [category]);
     const [balance, setBalance] = useState('');
     const [interestRate, setInterestRate] = useState('');
     const [budgetOrder, setBudgetOrder] = useState('');
@@ -126,16 +133,18 @@ export function AddAccountPage() {
                 </div>
 
                 {/* Budget Order Field */}
-                <div className="space-y-2">
-                    <label className="block text-sm font-semibold text-slate-600 dark:text-slate-400">Budget Order (Optional)</label>
-                    <input
-                        className="w-full h-14 px-4 rounded-lg bg-white dark:bg-primary/5 border border-slate-200 dark:border-primary/20 focus:border-primary focus:ring-1 focus:ring-primary outline-none transition-all text-slate-900 dark:text-slate-100"
-                        type="number"
-                        placeholder="e.g. 1"
-                        value={budgetOrder}
-                        onChange={(e) => setBudgetOrder(e.target.value)}
-                    />
-                </div>
+                {category === 'Current Account' && (
+                    <div className="space-y-2">
+                        <label className="block text-sm font-semibold text-slate-600 dark:text-slate-400">Budget Order (Optional)</label>
+                        <input
+                            className="w-full h-14 px-4 rounded-lg bg-white dark:bg-primary/5 border border-slate-200 dark:border-primary/20 focus:border-primary focus:ring-1 focus:ring-primary outline-none transition-all text-slate-900 dark:text-slate-100"
+                            type="number"
+                            placeholder="e.g. 1"
+                            value={budgetOrder}
+                            onChange={(e) => setBudgetOrder(e.target.value)}
+                        />
+                    </div>
+                )}
 
                 {/* Balance Field */}
                 <div className="space-y-2">

--- a/src/pages/AddBudgetPage.tsx
+++ b/src/pages/AddBudgetPage.tsx
@@ -118,6 +118,7 @@ export function AddBudgetPage() {
                             <select name="accountId" required value={accountId} onChange={(e) => setAccountId(e.target.value)} className="w-full appearance-none rounded-xl border border-slate-200 dark:border-primary/20 bg-white dark:bg-slate-900/50 p-4 pr-10 text-slate-900 dark:text-slate-100 focus:border-primary focus:ring-1 focus:ring-primary outline-none transition-all">
                                 <option value="" disabled>Select an account</option>
                                 {accounts
+                                    .filter(acc => acc.budgetOrder !== undefined && acc.budgetOrder !== null)
                                     .sort((a, b) => a.name.localeCompare(b.name))
                                     .map((acc) => (
                                         <option key={acc.id} value={acc.id}>{acc.nickname || acc.name}{acc.last4Digits ? ` (x${acc.last4Digits})` : ''}</option>

--- a/src/pages/AddPaymentPage.tsx
+++ b/src/pages/AddPaymentPage.tsx
@@ -202,6 +202,7 @@ export function AddPaymentPage() {
                             >
                                 <option value="" disabled>Select an account</option>
                                 {accounts
+                                    .filter(account => account.category === 'Current Account')
                                     .sort((a, b) => a.name.localeCompare(b.name))
                                     .map(account => (
                                         <option key={account.id} value={account.id}>{account.nickname || account.name}{account.last4Digits ? ` (x${account.last4Digits})` : ''}</option>

--- a/src/pages/EditAccountPage.tsx
+++ b/src/pages/EditAccountPage.tsx
@@ -161,16 +161,18 @@ export function EditAccountPage() {
                 </div>
 
                 {/* Budget Order Field */}
-                <div className="space-y-2">
-                    <label className="block text-sm font-semibold text-slate-600 dark:text-slate-400">Budget Order (Optional)</label>
-                    <input
-                        className="w-full h-14 px-4 rounded-lg bg-white dark:bg-primary/5 border border-slate-200 dark:border-primary/20 focus:border-primary focus:ring-1 focus:ring-primary outline-none transition-all text-slate-900 dark:text-slate-100"
-                        type="number"
-                        placeholder="e.g. 1"
-                        value={budgetOrder}
-                        onChange={(e) => setBudgetOrder(e.target.value)}
-                    />
-                </div>
+                {category === 'Current Account' && (
+                    <div className="space-y-2">
+                        <label className="block text-sm font-semibold text-slate-600 dark:text-slate-400">Budget Order (Optional)</label>
+                        <input
+                            className="w-full h-14 px-4 rounded-lg bg-white dark:bg-primary/5 border border-slate-200 dark:border-primary/20 focus:border-primary focus:ring-1 focus:ring-primary outline-none transition-all text-slate-900 dark:text-slate-100"
+                            type="number"
+                            placeholder="e.g. 1"
+                            value={budgetOrder}
+                            onChange={(e) => setBudgetOrder(e.target.value)}
+                        />
+                    </div>
+                )}
 
                 {/* Balance Field */}
                 <div className="space-y-2">

--- a/src/pages/EditBudgetPage.tsx
+++ b/src/pages/EditBudgetPage.tsx
@@ -154,6 +154,7 @@ export function EditBudgetPage() {
                             >
                                 <option value="" disabled>Select an account</option>
                                 {accounts
+                                    .filter(acc => acc.budgetOrder !== undefined && acc.budgetOrder !== null)
                                     .sort((a, b) => a.name.localeCompare(b.name))
                                     .map((acc) => (
                                         <option key={acc.id} value={acc.id}>{acc.nickname || acc.name}{acc.last4Digits ? ` (x${acc.last4Digits})` : ''}</option>

--- a/src/pages/EditPaymentPage.tsx
+++ b/src/pages/EditPaymentPage.tsx
@@ -174,6 +174,7 @@ export function EditPaymentPage() {
                             >
                                 <option value="" disabled>Select an account</option>
                                 {accounts
+                                    .filter(account => account.category === 'Current Account')
                                     .sort((a, b) => a.name.localeCompare(b.name))
                                     .map(account => (
                                         <option key={account.id} value={account.id}>{account.nickname || account.name}{account.last4Digits ? ` (x${account.last4Digits})` : ''}</option>


### PR DESCRIPTION
- Updated `AddBudgetPage` and `EditBudgetPage` to filter out accounts without a `budgetOrder`.
- Updated `AddPaymentPage` and `EditPaymentPage` to filter accounts to only `Current Account` type.
- Updated `AddAccountPage` and `EditAccountPage` to only display the Budget Order input if `category === 'Current Account'`, and introduced a `useEffect` hook to clear `budgetOrder` when category switches away from `Current Account`.

---
*PR created automatically by Jules for task [10793835846158623263](https://jules.google.com/task/10793835846158623263) started by @John-Bell*