### PR TITLE
Remove Location Field from Budgets

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -121,7 +121,6 @@ export interface Budget {
     name: string; // sub-category
     amount: number;
     frequency: string; // e.g. monthly, annual
-    paymentSource: string; // e.g. monthly, annual
     updatedAt?: number;
     // --- Import Fields ---
     importId?: string;

--- a/src/pages/AddBudgetPage.tsx
+++ b/src/pages/AddBudgetPage.tsx
@@ -12,18 +12,16 @@ export function AddBudgetPage() {
     const [name, setName] = useState('');
     const [amount, setAmount] = useState('');
     const [frequency, setFrequency] = useState('monthly');
-    const [paymentSource, setPaymentSource] = useState('');
     const [accountId, setAccountId] = useState('');
 
     const handleSave = async () => {
-        if (!name || !amount || !paymentSource || !accountId) return;
+        if (!name || !amount || !accountId) return;
 
         await db.budgets.add({
             id: crypto.randomUUID(),
             name,
             amount: parseFloat(amount) || 0,
             frequency,
-            paymentSource,
             accountId
         });
         navigate('/budgets');
@@ -94,20 +92,6 @@ export function AddBudgetPage() {
                         </div>
                         <div className="size-12 rounded-full bg-primary/20 flex items-center justify-center text-primary">
                             <Icon name="analytics" className="text-2xl" />
-                        </div>
-                    </div>
-
-                    {/* Location */}
-                    <div className="space-y-2">
-                        <label className="block text-sm font-semibold text-slate-700 dark:text-slate-300">Location</label>
-                        <div className="relative">
-                            <select name="paymentSource" value={paymentSource} onChange={(e) => setPaymentSource(e.target.value)} className="w-full appearance-none rounded-xl border border-slate-200 dark:border-primary/20 bg-white dark:bg-slate-900/50 p-4 pr-10 text-slate-900 dark:text-slate-100 focus:border-primary focus:ring-1 focus:ring-primary outline-none transition-all">
-                                <option disabled value="">Select a location</option>
-                                <option value="Groceries / Incidentals">Groceries / Incidentals</option>
-                                <option value="Monthly Bills">Monthly Bills</option>
-                                <option value="Annual Bills">Annual Bills</option>
-                            </select>
-                            <Icon name="expand_more" className="absolute right-4 top-1/2 -translate-y-1/2 pointer-events-none text-slate-400" />
                         </div>
                     </div>
 

--- a/src/pages/BudgetsPage.tsx
+++ b/src/pages/BudgetsPage.tsx
@@ -164,9 +164,6 @@ export function BudgetsPage() {
                                                 <div className="flex-1 flex flex-col min-w-0">
                                                     <div className="flex justify-between items-center w-full">
                                                         <h3 className="text-lg font-bold text-slate-900 dark:text-slate-100 truncate">{budget.name}</h3>
-                                                        <span className="text-[10px] font-bold px-2.5 py-1 bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-400 rounded-full uppercase tracking-wider whitespace-nowrap ml-2">
-                                                            {budget.paymentSource}
-                                                        </span>
                                                     </div>
                                                     <div className="flex items-center text-xs text-slate-500 dark:text-slate-400 gap-1.5 mt-0.5">
                                                         <span>Monthly: £{monthlyAmount.toFixed(2)}</span>
@@ -208,7 +205,6 @@ export function BudgetsPage() {
                                                         {status}
                                                     </span>
                                                 </div>
-                                                <p className="text-xs text-slate-500 dark:text-slate-400">Location: <span className="text-slate-700 dark:text-slate-300 capitalize">{budget.paymentSource}</span></p>
                                                 <div className="flex gap-4 mt-2">
                                                     <div>
                                                         <p className="text-[10px] uppercase tracking-wider text-slate-400 font-bold">{isAnnual ? 'As Monthly' : 'Monthly'}</p>

--- a/src/pages/EditBudgetPage.tsx
+++ b/src/pages/EditBudgetPage.tsx
@@ -15,7 +15,6 @@ export function EditBudgetPage() {
     const [name, setName] = useState('');
     const [amount, setAmount] = useState('');
     const [frequency, setFrequency] = useState('monthly');
-    const [paymentSource, setPaymentSource] = useState('monthly');
     const [accountId, setAccountId] = useState('');
 
     useEffect(() => {
@@ -23,19 +22,17 @@ export function EditBudgetPage() {
             setName(budget.name);
             setAmount(budget.amount.toString());
             setFrequency(budget.frequency);
-            setPaymentSource(budget.paymentSource);
             setAccountId(budget.accountId || '');
             }
     }, [budget]);
 
     const handleSave = async () => {
-        if (!id || !budget || !accountId) return;
+        if (!id || !name || !amount || !accountId) return;
 
         await db.budgets.update(id, {
             name,
             amount: parseFloat(amount) || 0,
             frequency,
-            paymentSource,
             accountId
         } );
         navigate('/budgets');
@@ -129,21 +126,8 @@ export function EditBudgetPage() {
                         </div>
                     </div>
 
-                    {/* Payment Source & Ownership */}
+                    {/* Account */}
                     <div className="grid grid-cols-1 gap-4">
-                        <div className="flex flex-col gap-2">
-                            <label className="text-slate-700 dark:text-slate-300 text-sm font-medium">Location</label>
-                            <select
-                                value={paymentSource}
-                                onChange={(e) => setPaymentSource(e.target.value)}
-                                className="custom-select w-full rounded-lg border border-slate-300 dark:border-primary/20 bg-white dark:bg-slate-900/50 p-3 text-slate-900 dark:text-slate-100 focus:ring-2 focus:ring-primary focus:border-transparent outline-none"
-                            >
-                                <option value="Groceries / Incidentals">Groceries / Incidentals</option>
-                                <option value="Monthly Bills">Monthly Bills</option>
-                                <option value="Annual Bills">Annual Bills</option>
-                            </select>
-                        </div>
-
                         <div className="flex flex-col gap-2">
                             <label className="text-slate-700 dark:text-slate-300 text-sm font-medium">Account</label>
                             <select

--- a/src/pages/ImportProcessor.tsx
+++ b/src/pages/ImportProcessor.tsx
@@ -7,7 +7,7 @@ import { DataImportService } from '../services/DataImportService';
 
 const TABLE_SCHEMAS: Record<string, string[]> = {
     accounts: ['id', 'name', 'balance', 'interestRate', 'category', 'ownerId', 'notes'],
-    budgets: ['id', 'importCategory', 'name', 'amount', 'frequency', 'paymentSource', 'ownership', 'importMappingName'],
+    budgets: ['id', 'importCategory', 'name', 'amount', 'frequency', 'ownership', 'importMappingName'],
     transactions: ['id', 'date', 'payee', 'amount', 'importCategory', 'type', 'icon', 'rawDesc']
 };
 

--- a/src/services/DataImportService.test.ts
+++ b/src/services/DataImportService.test.ts
@@ -128,7 +128,6 @@ describe('DataImportService', () => {
                 name: 'Groceries',
                 amount: 500,
                 frequency: 'monthly',
-                paymentSource: 'Monthly Bills',
                 updatedAt: Date.now()
             });
 
@@ -180,7 +179,6 @@ describe('DataImportService', () => {
             const b = budgets[0];
             expect(b.amount).toBe(50); // parsed correctly
             expect(b.frequency).toBe('monthly');
-            expect(b.paymentSource).toBe('Monthly Bills');
             expect((b as any).importCategory).toBeUndefined();
             expect(b.importId).toBe('import-file-2');
         });

--- a/src/services/DataImportService.ts
+++ b/src/services/DataImportService.ts
@@ -130,7 +130,6 @@ export class DataImportService {
                 delete mappedRow.importCategory;
             } else if (targetTable === 'budgets') {
                 if (!mappedRow.frequency) mappedRow.frequency = 'monthly';
-                if (!mappedRow.paymentSource) mappedRow.paymentSource = 'Monthly Bills';
 
                 // Cleanup temporary mapping field
                 delete mappedRow.importCategory;


### PR DESCRIPTION
The Location field (`paymentSource`) has been fully removed from the Budget schemas, forms, data import logic, and the UI since budgets are now directly linked to Accounts via `accountId`.

---
*PR created automatically by Jules for task [16565755645870338309](https://jules.google.com/task/16565755645870338309) started by @John-Bell*