### PR TITLE
Update Dashboard Account List

### DIFF
--- a/src/components/dashboard/DashboardAccountList.tsx
+++ b/src/components/dashboard/DashboardAccountList.tsx
@@ -76,10 +76,10 @@ export function DashboardAccountList({ accounts, budgets, transactions }: Dashbo
                         >
                             <div>
                                 <h2 className="text-xl font-bold text-slate-900 tracking-tight">
-                                    {account.name}
+                                    {account.nickname || account.name}
                                 </h2>
                                 {account.last4Digits && (
-                                    <p className="text-sm text-slate-400 font-normal">
+                                    <p className="text-base text-slate-400 font-normal">
                                         ..{account.last4Digits}
                                     </p>
                                 )}


### PR DESCRIPTION
This commit updates `DashboardAccountList` to:
- Use `account.nickname` instead of `account.name` for rendering, and fallback to the `account.name` if the nickname is missing.
- Make the account's last 4 digits more visible by changing the text class from `text-sm` to `text-base`.

---
*PR created automatically by Jules for task [11282090829648971257](https://jules.google.com/task/11282090829648971257) started by @John-Bell*