### PR TITLE
UI Updates: Budget Remaining display and Payment Account dropdown reordering

### DIFF
--- a/src/components/dashboard/DashboardAccountList.tsx
+++ b/src/components/dashboard/DashboardAccountList.tsx
@@ -127,12 +127,14 @@ export function DashboardAccountList({ accounts, budgets, transactions }: Dashbo
 
                                             {/* Budget Summary Row */}
                                             <div className="flex items-center justify-between px-1">
-                                                <span className="text-xs text-slate-500 uppercase tracking-wider font-semibold">
-                                                    BUDGETED: {formatCurrency(budgetTarget)}
-                                                </span>
-                                                <span className="text-xs text-slate-500 uppercase tracking-wider font-semibold">
-                                                    SPENT: {formatCurrency(budgetTotalSpent)}
-                                                </span>
+                                                <div className="flex flex-col">
+                                                    <span className="text-[10px] text-slate-400 uppercase tracking-wider font-bold">Budgeted</span>
+                                                    <span className="text-sm font-bold text-slate-700">{formatCurrency(budgetTarget)}</span>
+                                                </div>
+                                                <div className="flex flex-col items-end">
+                                                    <span className="text-[10px] text-slate-400 uppercase tracking-wider font-bold">Remaining</span>
+                                                    <span className="text-sm font-bold text-slate-700">{formatCurrency(budgetTarget - budgetTotalSpent)}</span>
+                                                </div>
                                             </div>
 
                                             {/* Transactions List */}

--- a/src/pages/AddPaymentPage.tsx
+++ b/src/pages/AddPaymentPage.tsx
@@ -107,6 +107,30 @@ export function AddPaymentPage() {
                     </div>
 
                     <div>
+                        <label className="block text-sm font-semibold text-slate-700 dark:text-slate-300 mb-1.5">Account</label>
+                        <div className="relative">
+                            <select
+                                required
+                                value={accountId}
+                                onChange={(e) => setAccountId(e.target.value)}
+                                className="w-full bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl px-4 py-3 text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary transition-colors appearance-none"
+                            >
+                                <option value="" disabled>Select an account</option>
+                                {accounts
+                                    .filter(account => account.category === 'Current Account')
+                                    .sort((a, b) => a.name.localeCompare(b.name))
+                                    .map(account => (
+                                        <option key={account.id} value={account.id}>{account.nickname || account.name}{account.last4Digits ? ` (x${account.last4Digits})` : ''}</option>
+                                    ))
+                                }
+                            </select>
+                            <div className="absolute inset-y-0 right-0 flex items-center pr-4 pointer-events-none text-slate-400">
+                                <span className="material-symbols-outlined">expand_more</span>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div>
                         <label className="block text-sm font-semibold text-slate-700 dark:text-slate-300 mb-1.5">Payee</label>
                         <input
                             type="text"
@@ -182,30 +206,6 @@ export function AddPaymentPage() {
                                     .sort((a, b) => a.name.localeCompare(b.name))
                                     .map(budget => (
                                         <option key={budget.id} value={budget.id}>{budget.name}</option>
-                                    ))
-                                }
-                            </select>
-                            <div className="absolute inset-y-0 right-0 flex items-center pr-4 pointer-events-none text-slate-400">
-                                <span className="material-symbols-outlined">expand_more</span>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div>
-                        <label className="block text-sm font-semibold text-slate-700 dark:text-slate-300 mb-1.5">Account</label>
-                        <div className="relative">
-                            <select
-                                required
-                                value={accountId}
-                                onChange={(e) => setAccountId(e.target.value)}
-                                className="w-full bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl px-4 py-3 text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary transition-colors appearance-none"
-                            >
-                                <option value="" disabled>Select an account</option>
-                                {accounts
-                                    .filter(account => account.category === 'Current Account')
-                                    .sort((a, b) => a.name.localeCompare(b.name))
-                                    .map(account => (
-                                        <option key={account.id} value={account.id}>{account.nickname || account.name}{account.last4Digits ? ` (x${account.last4Digits})` : ''}</option>
                                     ))
                                 }
                             </select>

--- a/src/pages/EditPaymentPage.tsx
+++ b/src/pages/EditPaymentPage.tsx
@@ -102,6 +102,30 @@ export function EditPaymentPage() {
                     </div>
 
                     <div>
+                        <label className="block text-sm font-semibold text-slate-700 dark:text-slate-300 mb-1.5">Account</label>
+                        <div className="relative">
+                            <select
+                                required
+                                value={accountId}
+                                onChange={(e) => setAccountId(e.target.value)}
+                                className="w-full bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl px-4 py-3 text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary transition-colors appearance-none"
+                            >
+                                <option value="" disabled>Select an account</option>
+                                {accounts
+                                    .filter(account => account.category === 'Current Account')
+                                    .sort((a, b) => a.name.localeCompare(b.name))
+                                    .map(account => (
+                                        <option key={account.id} value={account.id}>{account.nickname || account.name}{account.last4Digits ? ` (x${account.last4Digits})` : ''}</option>
+                                    ))
+                                }
+                            </select>
+                            <div className="absolute inset-y-0 right-0 flex items-center pr-4 pointer-events-none text-slate-400">
+                                <span className="material-symbols-outlined">expand_more</span>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div>
                         <label className="block text-sm font-semibold text-slate-700 dark:text-slate-300 mb-1.5">Payee</label>
                         <input
                             type="text"
@@ -154,30 +178,6 @@ export function EditPaymentPage() {
                                     .sort((a, b) => a.name.localeCompare(b.name))
                                     .map(budget => (
                                         <option key={budget.id} value={budget.id}>{budget.name}</option>
-                                    ))
-                                }
-                            </select>
-                            <div className="absolute inset-y-0 right-0 flex items-center pr-4 pointer-events-none text-slate-400">
-                                <span className="material-symbols-outlined">expand_more</span>
-                            </div>
-                        </div>
-                    </div>
-
-                    <div>
-                        <label className="block text-sm font-semibold text-slate-700 dark:text-slate-300 mb-1.5">Account</label>
-                        <div className="relative">
-                            <select
-                                required
-                                value={accountId}
-                                onChange={(e) => setAccountId(e.target.value)}
-                                className="w-full bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl px-4 py-3 text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary transition-colors appearance-none"
-                            >
-                                <option value="" disabled>Select an account</option>
-                                {accounts
-                                    .filter(account => account.category === 'Current Account')
-                                    .sort((a, b) => a.name.localeCompare(b.name))
-                                    .map(account => (
-                                        <option key={account.id} value={account.id}>{account.nickname || account.name}{account.last4Digits ? ` (x${account.last4Digits})` : ''}</option>
                                     ))
                                 }
                             </select>


### PR DESCRIPTION
This PR addresses two user requests:
1. It updates the budget summary row on the dashboard to display the 'Remaining' budget (target - spent) instead of just the amount 'Spent', and applies formatting to make the values bolder and more obvious.
2. It reorders the input fields on the Add/Edit Payment screens to place the 'Account' dropdown at the top, immediately below the Income/Expense type toggle, improving the user flow.

---
*PR created automatically by Jules for task [3393890011228069093](https://jules.google.com/task/3393890011228069093) started by @John-Bell*