### PR TITLE
fix: filter out accounts without budgets on dashboard

### DIFF
--- a/src/components/dashboard/DashboardAccountList.tsx
+++ b/src/components/dashboard/DashboardAccountList.tsx
@@ -11,12 +11,14 @@ interface DashboardAccountListProps {
 export function DashboardAccountList({ accounts, budgets, transactions }: DashboardAccountListProps) {
     const navigate = useNavigate();
 
-    // Sort accounts by budgetOrder
-    const sortedAccounts = [...accounts].sort((a, b) => {
-        const orderA = a.budgetOrder ?? 9999;
-        const orderB = b.budgetOrder ?? 9999;
-        return orderA - orderB;
-    });
+    // Filter out accounts with no budgets, then sort by budgetOrder
+    const sortedAccounts = [...accounts]
+        .filter(account => budgets.some(b => b.accountId === account.id))
+        .sort((a, b) => {
+            const orderA = a.budgetOrder ?? 9999;
+            const orderB = b.budgetOrder ?? 9999;
+            return orderA - orderB;
+        });
 
     const now = new Date();
     const currentMonth = now.getMonth();


### PR DESCRIPTION
Closes issue where accounts without budgets were being displayed on the dashboard list. Modifies `DashboardAccountList.tsx` to filter the `accounts` array before sorting and rendering.

---
*PR created automatically by Jules for task [2120016409187019378](https://jules.google.com/task/2120016409187019378) started by @John-Bell*