### PR TITLE
Fix account balance rounding and conditionally hide AER

### DIFF
--- a/src/components/accounts/AccountCard.tsx
+++ b/src/components/accounts/AccountCard.tsx
@@ -15,7 +15,7 @@ interface AccountCardProps extends HTMLAttributes<HTMLDivElement> {
     ownerTag: string;
     ownerTagColor: 'purple' | 'blue' | 'pink';
     balance: string;
-    rate: string;
+    rate?: string;
     isStale?: boolean;
     isWarned?: boolean;
     updatedAt: string;
@@ -112,10 +112,12 @@ export function AccountCard({
                     <span className="text-xs text-slate-500 dark:text-[#9db9b0] mb-0.5">Current Balance</span>
                     <span className="text-2xl font-extrabold text-slate-900 dark:text-white tracking-tight">{balance}</span>
                 </div>
-                <div className="flex flex-col items-end">
-                    <span className="text-xs text-slate-500 dark:text-[#9db9b0] mb-0.5">AER</span>
-                    <span className={cn('text-2xl font-bold', isWarned ? 'text-slate-400 dark:text-slate-500' : 'text-primary')}>{rate}</span>
-                </div>
+                {rate && (
+                    <div className="flex flex-col items-end">
+                        <span className="text-xs text-slate-500 dark:text-[#9db9b0] mb-0.5">AER</span>
+                        <span className={cn('text-2xl font-bold', isWarned ? 'text-slate-400 dark:text-slate-500' : 'text-primary')}>{rate}</span>
+                    </div>
+                )}
             </div>
 
             <div className="flex items-center justify-between pt-3 border-t border-gray-100 dark:border-[#283933]">

--- a/src/pages/AccountsPage.tsx
+++ b/src/pages/AccountsPage.tsx
@@ -57,8 +57,8 @@ export function AccountsPage() {
             category: acc.category,
             ownerTag: acc.ownerId === 'joint' ? 'Joint' : (acc.ownerId === 'person1' ? p1Name : p2Name),
             ownerTagColor,
-            balance: new Intl.NumberFormat('en-GB', { style: 'currency', currency: 'GBP', maximumFractionDigits: 0 }).format(acc.balance),
-            rate: acc.interestRate.toFixed(2) + '%',
+            balance: new Intl.NumberFormat('en-GB', { style: 'currency', currency: 'GBP', minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(acc.balance),
+            rate: acc.interestRate === 0 ? undefined : acc.interestRate.toFixed(2) + '%',
             updatedAt: formatRelativeTime(acc.updatedAt),
             alertText: acc.alertText,
             alertType: acc.alertType as any,
@@ -69,7 +69,8 @@ export function AccountsPage() {
     const formattedTotalSavings = new Intl.NumberFormat('en-GB', {
         style: 'currency',
         currency: 'GBP',
-        maximumFractionDigits: 0
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2
     }).format(totalSavingsValue);
 
     const blendedRateValue = calculateBlendedRate(rawAccounts);


### PR DESCRIPTION
Fixes the accounts page to display balances rounded to exactly 2 decimal places and hides the AER if it is zero.

---
*PR created automatically by Jules for task [16457902865103449901](https://jules.google.com/task/16457902865103449901) started by @John-Bell*