### PR TITLE
fix: exclude ISA and Premium Bonds from untaxed interest tax calculation

### DIFF
--- a/src/hooks/useTaxCalculations.ts
+++ b/src/hooks/useTaxCalculations.ts
@@ -41,6 +41,10 @@ export function useTaxCalculations(): UseTaxCalculationsResult {
 
         if (dbAccounts) {
             dbAccounts.forEach(acc => {
+                const taxFreeCategories = ['Cash ISA', 'Shares ISA', 'Premium Bonds'];
+                if (acc.category && taxFreeCategories.includes(acc.category as string)) {
+                    return;
+                }
                 const amount = (acc.balance || 0) * ((acc.interestRate || 0) / 100);
                 if (acc.ownerId === 'person1') p1Incomes.interest += amount;
                 else if (acc.ownerId === 'person2') p2Incomes.interest += amount;


### PR DESCRIPTION
Exclude tax-free accounts from untaxed interest calculation

The `useTaxCalculations` hook correctly looped through all `dbAccounts` to calculate untaxed interest. However, certain accounts such as Cash ISAs are exempt from tax, meaning their interest should not contribute to the total untaxed interest.

This PR adds a condition inside the `dbAccounts.forEach` loop to check if the account's category matches `'Cash ISA'`, `'Shares ISA'`, or `'Premium Bonds'`. If it does, the hook skips adding the interest to the incomes.

---
*PR created automatically by Jules for task [3299412459420010424](https://jules.google.com/task/3299412459420010424) started by @John-Bell*