### PR TITLE
Update dashboard to highlight overbudget items in red

### DIFF
--- a/src/components/dashboard/DashboardAccountList.tsx
+++ b/src/components/dashboard/DashboardAccountList.tsx
@@ -129,7 +129,7 @@ export function DashboardAccountList({ accounts, budgets, transactions }: Dashbo
                                                 <div className="text-right text-slate-700 font-medium">
                                                     {budgetTarget.toLocaleString('en-GB', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
                                                 </div>
-                                                <div className="text-right font-bold text-[#1DAF61]">
+                                                <div className={`text-right font-bold ${budgetTotalSpent > budgetTarget ? 'text-red-500' : 'text-[#1DAF61]'}`}>
                                                     {budgetTotalSpent.toLocaleString('en-GB', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
                                                 </div>
                                                 <div className="flex items-center justify-end gap-2 text-slate-400">
@@ -262,7 +262,9 @@ export function DashboardAccountList({ accounts, budgets, transactions }: Dashbo
                                                     </div>
                                                     <div className="flex flex-col items-end">
                                                         <span className="text-[10px] text-slate-400 uppercase tracking-wider font-bold">Remaining</span>
-                                                        <span className="text-sm font-bold text-slate-700">{formatCurrency(budgetTarget - budgetTotalSpent)}</span>
+                                                        <span className={`text-sm font-bold ${budgetTarget - budgetTotalSpent < 0 ? 'text-red-500' : 'text-slate-700'}`}>
+                                                            {formatCurrency(budgetTarget - budgetTotalSpent)}
+                                                        </span>
                                                     </div>
                                                 </div>
 


### PR DESCRIPTION
Based on user feedback, dashboard views for accounts and budgets have been updated to turn overspent balances red.

On mobile devices, the "Remaining" balance will appear red when it evaluates to less than 0. On Desktop/Tablet, the "Total Spent" amount will appear red when it exceeds the budget target.

---
*PR created automatically by Jules for task [856006881853039169](https://jules.google.com/task/856006881853039169) started by @John-Bell*