### PR TITLE
Add useInterestAccruals Hook

### DIFF
--- a/src/hooks/useInterestAccruals.ts
+++ b/src/hooks/useInterestAccruals.ts
@@ -1,0 +1,35 @@
+import { useLiveQuery } from 'dexie-react-hooks';
+import { db } from '../lib/db';
+import type { InterestAccrual } from '../lib/db';
+
+export function useInterestAccruals(accountId?: string) {
+    const accruals = useLiveQuery(
+        async () => {
+            let query = db.interestAccruals.toCollection();
+
+            if (accountId) {
+                query = db.interestAccruals.where('accountId').equals(accountId);
+            }
+
+            return await query.reverse().sortBy('date');
+        },
+        [accountId]
+    );
+
+    return {
+        accruals,
+        isLoading: accruals === undefined
+    };
+}
+
+export const addInterestAccrual = async (accrualData: Omit<InterestAccrual, 'id' | 'updatedAt'>) => {
+    return db.interestAccruals.add({
+        id: crypto.randomUUID(),
+        ...accrualData,
+        updatedAt: Date.now()
+    });
+};
+
+export const deleteInterestAccrual = async (id: string) => {
+    return db.interestAccruals.delete(id);
+};


### PR DESCRIPTION
Adds a new hook to handle fetching and modifying manual interest accruals for accounts, following Dexie reactivity and local-first architectures.

---
*PR created automatically by Jules for task [11836923005829789892](https://jules.google.com/task/11836923005829789892) started by @John-Bell*