### PR TITLE
Fix manual ledger date field width on landscape iPads

### DIFF
--- a/src/components/accounts/InterestLedger.tsx
+++ b/src/components/accounts/InterestLedger.tsx
@@ -56,7 +56,7 @@ export function InterestLedger({ accountId }: InterestLedgerProps) {
 
             {/* Add New Entry Form */}
             <div className="p-5 border-b border-slate-100 dark:border-primary/10">
-                <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-4 mb-4">
+                <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4 mb-4">
                     <div>
                         <label className="block text-xs font-bold text-slate-400 uppercase tracking-wider mb-2">Month & Year</label>
                         <input

--- a/src/pages/EditAccountPage.tsx
+++ b/src/pages/EditAccountPage.tsx
@@ -114,8 +114,8 @@ export function EditAccountPage() {
                 <h1 className="ml-4 text-xl font-bold tracking-tight">Edit Account</h1>
             </header>
 
-            <div className="flex-1 overflow-y-auto p-4 lg:p-6 flex flex-col lg:flex-row gap-8">
-                <main className={`space-y-6 ${interestTrackingMethod === 'manual' ? 'lg:w-[calc(40%-1rem)]' : 'flex-1'}`}>
+            <div className="flex-1 overflow-y-auto p-4 lg:p-6 flex flex-col xl:flex-row gap-8">
+                <main className={`space-y-6 ${interestTrackingMethod === 'manual' ? 'xl:w-[calc(40%-1rem)]' : 'flex-1'}`}>
                     <h2 className="text-xs font-bold text-slate-400 uppercase tracking-wider mb-2">GENERAL INFORMATION</h2>
                     {/* Account Name Field */}
                 <div className="space-y-2">
@@ -320,7 +320,7 @@ export function EditAccountPage() {
                 </main>
 
                 {interestTrackingMethod === 'manual' && (
-                    <aside className="w-full lg:w-[calc(60%-1rem)]">
+                    <aside className="w-full xl:w-[calc(60%-1rem)]">
                         <InterestLedger accountId={account?.id || ''} currentBalance={parseFloat(balance) || 0} />
                     </aside>
                 )}


### PR DESCRIPTION
- Change `lg:flex-row` to `xl:flex-row` in `EditAccountPage.tsx`
- Change `sm:grid-cols-2 xl:grid-cols-3` to `sm:grid-cols-2 md:grid-cols-3` in `InterestLedger.tsx`

---
*PR created automatically by Jules for task [1416156653318872319](https://jules.google.com/task/1416156653318872319) started by @John-Bell*