### PR TITLE
fix: adjust flex width of interest ledger fields to accommodate iOS date inputs

### DIFF
--- a/src/components/accounts/InterestLedger.tsx
+++ b/src/components/accounts/InterestLedger.tsx
@@ -57,7 +57,7 @@ export function InterestLedger({ accountId }: InterestLedgerProps) {
             {/* Add New Entry Form */}
             <div className="p-5 border-b border-slate-100 dark:border-primary/10">
                 <div className="flex flex-wrap gap-4 mb-4">
-                    <div className="flex-1 min-w-[200px]">
+                    <div className="flex-[1.5] min-w-[200px]">
                         <label className="block text-xs font-bold text-slate-400 uppercase tracking-wider mb-2">Month & Year</label>
                         <input
                             type="month"
@@ -66,7 +66,7 @@ export function InterestLedger({ accountId }: InterestLedgerProps) {
                             onChange={(e) => setMonthYear(e.target.value)}
                         />
                     </div>
-                    <div className="flex-1 min-w-[200px]">
+                    <div className="flex-1 min-w-[130px]">
                         <label className="block text-xs font-bold text-slate-400 uppercase tracking-wider mb-2">Month-End Balance</label>
                         <div className="relative">
                             <span className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400 font-medium text-sm">£</span>
@@ -80,7 +80,7 @@ export function InterestLedger({ accountId }: InterestLedgerProps) {
                             />
                         </div>
                     </div>
-                    <div className="flex-1 min-w-[200px]">
+                    <div className="flex-1 min-w-[130px]">
                         <label className="block text-xs font-bold text-slate-400 uppercase tracking-wider mb-2">Interest Amount</label>
                         <div className="relative">
                             <span className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400 font-medium text-sm">£</span>


### PR DESCRIPTION
* Increased the `flex` scale for the "Month & Year" input wrapper to `flex-[1.5]` to grant it more horizontal space.
* Decreased the `min-w` values for the "Month-End Balance" and "Interest Amount" input wrappers from `200px` to `130px`. 
* This provides the `type="month"` input enough room to expand gracefully according to iOS minimum width restrictions without forcing elements onto a new line or causing premature wrapping on landscape tablets.

---
*PR created automatically by Jules for task [12566041907282168089](https://jules.google.com/task/12566041907282168089) started by @John-Bell*