### PR TITLE
Fix CSS Grid blowout for native type="month" inputs on iOS/iPadOS Safari

### DIFF
--- a/src/components/accounts/InterestLedger.tsx
+++ b/src/components/accounts/InterestLedger.tsx
@@ -57,16 +57,16 @@ export function InterestLedger({ accountId }: InterestLedgerProps) {
             {/* Add New Entry Form */}
             <div className="p-5 border-b border-slate-100 dark:border-primary/10">
                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-4">
-                    <div className="sm:col-span-2">
+                    <div className="sm:col-span-2 min-w-0 w-full">
                         <label className="block text-xs font-bold text-slate-400 uppercase tracking-wider mb-2">Month & Year</label>
                         <input
                             type="month"
-                            className="w-full h-11 px-3 rounded-xl bg-white dark:bg-primary/10 border border-slate-200 dark:border-primary/20 focus:border-primary focus:ring-1 focus:ring-primary outline-none text-sm text-slate-900 dark:text-slate-100 placeholder-slate-400 dark:[color-scheme:dark]"
+                            className="w-full h-11 px-3 rounded-xl bg-white dark:bg-primary/10 border border-slate-200 dark:border-primary/20 focus:border-primary focus:ring-1 focus:ring-primary outline-none text-sm text-slate-900 dark:text-slate-100 placeholder-slate-400 dark:[color-scheme:dark] block max-w-full appearance-none min-w-0"
                             value={monthYear}
                             onChange={(e) => setMonthYear(e.target.value)}
                         />
                     </div>
-                    <div>
+                    <div className="min-w-0 w-full">
                         <label className="block text-xs font-bold text-slate-400 uppercase tracking-wider mb-2">Month-End Balance</label>
                         <div className="relative">
                             <span className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400 font-medium text-sm">£</span>
@@ -80,7 +80,7 @@ export function InterestLedger({ accountId }: InterestLedgerProps) {
                             />
                         </div>
                     </div>
-                    <div>
+                    <div className="min-w-0 w-full">
                         <label className="block text-xs font-bold text-slate-400 uppercase tracking-wider mb-2">Interest Amount</label>
                         <div className="relative">
                             <span className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400 font-medium text-sm">£</span>


### PR DESCRIPTION
Fixes a visual bug on iOS/iPadOS Safari where the native `<input type="month">` control breaks out of its parent grid cell in the `InterestLedger.tsx` component.

1. Applied `min-w-0 w-full` to the `sm:col-span-2` wrapper for the Month & Year input.
2. Applied `min-w-0 w-full` to the respective `div` wrappers for the Month-End Balance and Interest Amount inputs.
3. Added utility classes `block max-w-full appearance-none min-w-0` directly to the `<input type="month">` to strictly clamp its rendering width to its constrained parent.

These changes strictly pertain to the UI presentation layer as requested. Validated codebase build and automated test suite execution.

---
*PR created automatically by Jules for task [666951815652474716](https://jules.google.com/task/666951815652474716) started by @John-Bell*