### PR TITLE
Replace Blended Rate with Total non Pensions Savings

### DIFF
--- a/src/components/accounts/PortfolioOverview.tsx
+++ b/src/components/accounts/PortfolioOverview.tsx
@@ -1,12 +1,9 @@
-import { Icon } from '@/components/ui/Icon';
-
 interface PortfolioOverviewProps {
     totalSavings: string;
-    blendedRate: string;
-    trend: 'up' | 'down' | 'flat';
+    nonPensionSavings: string;
 }
 
-export function PortfolioOverview({ totalSavings, blendedRate, trend }: PortfolioOverviewProps) {
+export function PortfolioOverview({ totalSavings, nonPensionSavings }: PortfolioOverviewProps) {
     return (
         <div className="grid grid-cols-2 gap-3 mb-4">
             <div className="bg-white dark:bg-surface-dark rounded-xl p-3 border border-gray-100 dark:border-[#283933] shadow-sm flex flex-col items-center justify-center text-center">
@@ -16,12 +13,9 @@ export function PortfolioOverview({ totalSavings, blendedRate, trend }: Portfoli
 
             <div className="bg-white dark:bg-surface-dark rounded-xl p-3 border border-gray-100 dark:border-[#283933] shadow-sm flex flex-col items-center justify-center text-center relative overflow-hidden group">
                 <div className="absolute inset-0 bg-primary/5 dark:bg-primary/10"></div>
-                <p className="text-xs font-medium text-slate-500 dark:text-[#9db9b0] mb-1">Blended Rate</p>
+                <p className="text-xs font-medium text-slate-500 dark:text-[#9db9b0] mb-1">Total non Pensions Savings</p>
                 <div className="flex items-center gap-1">
-                    <p className="text-2xl font-bold tracking-tight text-primary">{blendedRate}</p>
-                    {trend === 'up' && <Icon name="trending_up" className="text-sm text-primary" />}
-                    {trend === 'down' && <Icon name="trending_down" className="text-sm text-red-500" />}
-                    {trend === 'flat' && <Icon name="trending_flat" className="text-sm text-slate-400" />}
+                    <p className="text-2xl font-bold tracking-tight text-primary">{nonPensionSavings}</p>
                 </div>
             </div>
         </div>

--- a/src/pages/AccountsPage.tsx
+++ b/src/pages/AccountsPage.tsx
@@ -5,7 +5,7 @@ import { useLiveQuery } from 'dexie-react-hooks';
 import { db } from '@/lib/db';
 import { useStore } from '@/store/useStore';
 import { formatRelativeTime } from '@/lib/utils';
-import { calculateTotalSavings, calculateBlendedRate } from '@/services/accountCalculations';
+import { calculateTotalSavings, calculateNonPensionSavings } from '@/services/accountCalculations';
 import { AppLayout } from '../components/layout/AppLayout';
 import { Header } from '../components/layout/Header';
 import { Icon } from '../components/ui/Icon';
@@ -22,7 +22,6 @@ export function AccountsPage() {
     const [sortBy, setSortBy] = useState<'rate' | 'name'>('rate');
 
     const rawAccounts = useLiveQuery(() => db.accounts.toArray()) || [];
-    const allAccruals = useLiveQuery(() => db.interestAccruals.toArray()) || [];
 
     const sortedRawAccounts = [...rawAccounts].sort((a, b) => {
         if (sortBy === 'rate') {
@@ -74,8 +73,13 @@ export function AccountsPage() {
         maximumFractionDigits: 2
     }).format(totalSavingsValue);
 
-    const blendedRateValue = calculateBlendedRate(rawAccounts, allAccruals);
-    const formattedBlendedRate = `${blendedRateValue.toFixed(2)}%`;
+    const nonPensionSavingsValue = calculateNonPensionSavings(rawAccounts);
+    const formattedNonPensionSavings = new Intl.NumberFormat('en-GB', {
+        style: 'currency',
+        currency: 'GBP',
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2
+    }).format(nonPensionSavingsValue);
 
     const filteredAccounts = mappedAccounts.filter(acc => acc.ownerId === activeAccountsTab);
 
@@ -97,7 +101,7 @@ export function AccountsPage() {
             }
         >
             <div className="px-4 pb-4">
-                <PortfolioOverview totalSavings={formattedTotalSavings} blendedRate={formattedBlendedRate} trend="up" />
+                <PortfolioOverview totalSavings={formattedTotalSavings} nonPensionSavings={formattedNonPensionSavings} />
 
                 <button
                     onClick={() => navigate('/accounts/add')}

--- a/src/services/accountCalculations.ts
+++ b/src/services/accountCalculations.ts
@@ -5,6 +5,10 @@ export function calculateTotalSavings(accounts: Account[]): number {
     return accounts.reduce((sum, acc) => sum + (acc.balance || 0), 0);
 }
 
+export function calculateNonPensionSavings(accounts: Account[]): number {
+    return accounts.reduce((sum, acc) => acc.category !== 'DC Pension' ? sum + (acc.balance || 0) : sum, 0);
+}
+
 export function calculateBlendedRate(accounts: Account[], allAccruals: InterestAccrual[] = []): number {
     const totalSavingsValueForRate = accounts.reduce((sum, acc) => sum + (acc.balance || 0), 0);
     const totalInterestValue = accounts.reduce((sum, acc) => {


### PR DESCRIPTION
Replaced the "Blended Rate" summary widget on the accounts page with a "Total non Pensions Savings" widget. The new metric calculates the total balance of all accounts, explicitly excluding any accounts categorized as "DC Pension".

---
*PR created automatically by Jules for task [16699394345188226399](https://jules.google.com/task/16699394345188226399) started by @John-Bell*