### PR TITLE
Add Account Filter to Transactions Page

### DIFF
--- a/src/pages/AddPaymentPage.tsx
+++ b/src/pages/AddPaymentPage.tsx
@@ -1,13 +1,15 @@
 import { useState } from 'react';
 import { AppLayout } from '../components/layout/AppLayout';
 import { Header } from '../components/layout/Header';
-import { useNavigate } from 'react-router-dom';
+import { useNavigate, useSearchParams } from 'react-router-dom';
 import { db } from '@/lib/db';
 import { v4 as uuidv4 } from 'uuid';
 import { useLiveQuery } from 'dexie-react-hooks';
 
 export function AddPaymentPage() {
     const navigate = useNavigate();
+    const [searchParams] = useSearchParams();
+    const urlAccountId = searchParams.get('accountId') || '';
 
     const budgets = useLiveQuery(() => db.budgets.toArray()) || [];
     const accounts = useLiveQuery(() => db.accounts.toArray()) || [];
@@ -15,7 +17,7 @@ export function AddPaymentPage() {
     const [payee, setPayee] = useState('');
     const [amount, setAmount] = useState('');
     const [budgetId, setBudgetId] = useState('');
-    const [accountId, setAccountId] = useState('');
+    const [accountId, setAccountId] = useState(urlAccountId);
     const [type, setType] = useState<'income' | 'expense'>('expense');
     const [date, setDate] = useState(() => new Date().toISOString().split('T')[0]);
     const [suggestedBudgetIds, setSuggestedBudgetIds] = useState<string[]>([]);
@@ -36,7 +38,11 @@ export function AddPaymentPage() {
             accountId
         });
 
-        navigate('/transactions');
+        if (urlAccountId) {
+            navigate(`/transactions?accountId=${urlAccountId}`);
+        } else {
+            navigate('/transactions');
+        }
     };
 
     const handlePayeeChange = async (e: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/pages/EditPaymentPage.tsx
+++ b/src/pages/EditPaymentPage.tsx
@@ -1,13 +1,15 @@
 import { useState, useEffect } from 'react';
 import { AppLayout } from '../components/layout/AppLayout';
 import { Header } from '../components/layout/Header';
-import { useNavigate, useParams } from 'react-router-dom';
+import { useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { db } from '@/lib/db';
 import { useLiveQuery } from 'dexie-react-hooks';
 
 export function EditPaymentPage() {
     const { id } = useParams();
     const navigate = useNavigate();
+    const [searchParams] = useSearchParams();
+    const urlAccountId = searchParams.get('accountId') || '';
 
     const transaction = useLiveQuery(() => db.transactions.get(id as string));
     const budgets = useLiveQuery(() => db.budgets.toArray()) || [];
@@ -48,14 +50,22 @@ export function EditPaymentPage() {
             accountId
         });
 
-        navigate('/transactions');
+        if (urlAccountId) {
+            navigate(`/transactions?accountId=${urlAccountId}`);
+        } else {
+            navigate('/transactions');
+        }
     };
 
     const handleDelete = async () => {
         if (!id) return;
         if (confirm('Are you sure you want to delete this payment?')) {
             await db.transactions.delete(id);
-            navigate('/transactions');
+            if (urlAccountId) {
+                navigate(`/transactions?accountId=${urlAccountId}`);
+            } else {
+                navigate('/transactions');
+            }
         }
     };
 

--- a/src/pages/TransactionsPage.tsx
+++ b/src/pages/TransactionsPage.tsx
@@ -5,12 +5,24 @@ import { Icon } from '../components/ui/Icon';
 import { useLiveQuery } from 'dexie-react-hooks';
 import { db } from '@/lib/db';
 import type { Transaction } from '@/lib/db';
-import { Link, useNavigate } from 'react-router-dom';
+import { Link, useNavigate, useSearchParams } from 'react-router-dom';
 
 export function TransactionsPage() {
     const navigate = useNavigate();
-    const transactions = useLiveQuery(() => db.transactions.orderBy('date').reverse().toArray()) || [];
+    const [searchParams, setSearchParams] = useSearchParams();
+    const selectedAccountId = searchParams.get('accountId') || '';
+
+    const allTransactions = useLiveQuery(() => db.transactions.orderBy('date').reverse().toArray()) || [];
+    const accounts = useLiveQuery(() => db.accounts.toArray()) || [];
     const budgets = useLiveQuery(() => db.budgets.toArray()) || [];
+
+    const currentAccounts = accounts
+        .filter(account => account.category === 'Current Account')
+        .sort((a, b) => a.name.localeCompare(b.name));
+
+    const transactions = selectedAccountId
+        ? allTransactions.filter(tx => tx.accountId === selectedAccountId)
+        : allTransactions;
 
     const budgetsMap = Object.fromEntries(budgets.map(b => [b.id, b]));
 
@@ -55,13 +67,40 @@ export function TransactionsPage() {
             }
         >
             <div className="flex flex-col gap-8 px-4 py-6 pb-24">
-                <button
-                    onClick={() => navigate('/transactions/add')}
-                    className="w-full flex items-center justify-center gap-2 bg-primary text-black font-semibold py-3 rounded-xl shadow-[0_4px_14px_0_rgba(255,184,80,0.39)] hover:brightness-110 active:scale-[0.98] transition-all"
-                >
-                    <Icon name="add" className="text-xl" />
-                    <span>Add Payment</span>
-                </button>
+                <div className="flex flex-col gap-4">
+                    <div className="relative">
+                        <select
+                            value={selectedAccountId}
+                            onChange={(e) => {
+                                const newAccountId = e.target.value;
+                                if (newAccountId) {
+                                    setSearchParams({ accountId: newAccountId });
+                                } else {
+                                    setSearchParams({});
+                                }
+                            }}
+                            className="w-full bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl px-4 py-3 text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary transition-colors appearance-none font-semibold shadow-sm"
+                        >
+                            <option value="">All Accounts</option>
+                            {currentAccounts.map(account => (
+                                <option key={account.id} value={account.id}>
+                                    {account.nickname || account.name}{account.last4Digits ? ` (x${account.last4Digits})` : ''}
+                                </option>
+                            ))}
+                        </select>
+                        <div className="absolute inset-y-0 right-0 flex items-center pr-4 pointer-events-none text-slate-400">
+                            <Icon name="expand_more" className="text-xl" />
+                        </div>
+                    </div>
+
+                    <button
+                        onClick={() => navigate(selectedAccountId ? `/transactions/add?accountId=${selectedAccountId}` : '/transactions/add')}
+                        className="w-full flex items-center justify-center gap-2 bg-primary text-black font-semibold py-3 rounded-xl shadow-[0_4px_14px_0_rgba(255,184,80,0.39)] hover:brightness-110 active:scale-[0.98] transition-all"
+                    >
+                        <Icon name="add" className="text-xl" />
+                        <span>Add Payment</span>
+                    </button>
+                </div>
 
                 {Object.entries(groupedTransactions).map(([dateLabel, dailyTransactions]) => (
                     <section key={dateLabel}>
@@ -70,7 +109,7 @@ export function TransactionsPage() {
                         </div>
                         <div className="space-y-1">
                             {dailyTransactions.map((tx) => (
-                                <Link to={`/transactions/edit/${tx.id}`} key={tx.id} className="group flex items-center gap-4 py-4 hover:bg-primary/5 transition-colors cursor-pointer border-b border-slate-100 dark:border-primary/5">
+                                <Link to={selectedAccountId ? `/transactions/edit/${tx.id}?accountId=${selectedAccountId}` : `/transactions/edit/${tx.id}`} key={tx.id} className="group flex items-center gap-4 py-4 hover:bg-primary/5 transition-colors cursor-pointer border-b border-slate-100 dark:border-primary/5">
                                     <div className="size-12 min-w-[3rem] rounded-xl bg-primary/10 flex items-center justify-center text-primary">
                                         <Icon name={tx.icon} />
                                     </div>


### PR DESCRIPTION
This submission implements the user request to add an account filter (specifically for 'Current Account' types) to the top of the payments/transactions page. The filter successfully subsets the displayed transactions. It also ensures that when clicking "Add Payment", the selected account is pre-filled, and when returning from an add/edit form, the filter remains active using persistent URL parameters.

---
*PR created automatically by Jules for task [4305128287606290948](https://jules.google.com/task/4305128287606290948) started by @John-Bell*