### PR TITLE
Fix AddPaymentPage navigation and budget pre-selection

### DIFF
--- a/src/components/dashboard/DashboardAccountList.tsx
+++ b/src/components/dashboard/DashboardAccountList.tsx
@@ -135,7 +135,7 @@ export function DashboardAccountList({ accounts, budgets, transactions }: Dashbo
                                                 <div className="flex items-center justify-end gap-2 text-slate-400">
                                                     <div
                                                         className="cursor-pointer hover:text-slate-700 transition-colors"
-                                                        onClick={() => navigate(`/transactions/add?budgetId=${budget.id}&accountId=${account.id}`)}
+                                                        onClick={() => navigate(`/transactions/add?budgetId=${budget.id}&accountId=${account.id}&from=dashboard`)}
                                                     >
                                                         <Icon name="receipt_long" className="w-5 h-5" />
                                                     </div>
@@ -241,7 +241,7 @@ export function DashboardAccountList({ accounts, budgets, transactions }: Dashbo
                                                     <div className="flex items-center gap-4 text-slate-500">
                                                         <div
                                                             className="cursor-pointer"
-                                                            onClick={() => navigate(`/transactions/add?budgetId=${budget.id}&accountId=${account.id}`)}
+                                                            onClick={() => navigate(`/transactions/add?budgetId=${budget.id}&accountId=${account.id}&from=dashboard`)}
                                                         >
                                                             <Icon name="receipt_long" className="w-6 h-6 hover:text-slate-800 transition-colors" />
                                                         </div>

--- a/src/pages/AddPaymentPage.tsx
+++ b/src/pages/AddPaymentPage.tsx
@@ -10,13 +10,15 @@ export function AddPaymentPage() {
     const navigate = useNavigate();
     const [searchParams] = useSearchParams();
     const urlAccountId = searchParams.get('accountId') || '';
+    const urlBudgetId = searchParams.get('budgetId') || '';
+    const from = searchParams.get('from') || '';
 
     const budgets = useLiveQuery(() => db.budgets.toArray()) || [];
     const accounts = useLiveQuery(() => db.accounts.toArray()) || [];
 
     const [payee, setPayee] = useState('');
     const [amount, setAmount] = useState('');
-    const [budgetId, setBudgetId] = useState('');
+    const [budgetId, setBudgetId] = useState(urlBudgetId);
     const [accountId, setAccountId] = useState(urlAccountId);
     const [type, setType] = useState<'income' | 'expense'>('expense');
     const [date, setDate] = useState(() => new Date().toISOString().split('T')[0]);
@@ -38,7 +40,9 @@ export function AddPaymentPage() {
             accountId
         });
 
-        if (urlAccountId) {
+        if (from === 'dashboard') {
+            navigate('/');
+        } else if (urlAccountId) {
             navigate(`/transactions?accountId=${urlAccountId}`);
         } else {
             navigate('/transactions');


### PR DESCRIPTION
Fixed an issue where the Add Payment page did not pre-select the correct budget when navigated to from the Dashboard. Additionally, ensuring that saving a payment from the dashboard accurately returns the user to the dashboard, rather than hardcoding navigation to the transactions page.

---
*PR created automatically by Jules for task [2926183955291201833](https://jules.google.com/task/2926183955291201833) started by @John-Bell*