### PR TITLE
Refactor `calculateProjectedAnnualInterest` logic to handle tax year boundaries and account maturity

### DIFF
--- a/src/constants/taxConstants.ts
+++ b/src/constants/taxConstants.ts
@@ -182,3 +182,15 @@ export const getDefaultTaxYear = (taxYear?: string): string => {
   const currentYear = getCurrentTaxYearKey();
   return requestedYear ?? (TAX_YEAR_CONSTANTS[currentYear] ? currentYear : DEFAULT_TAX_YEAR);
 };
+
+export const getTaxYearDates = (taxYear?: string): { startTs: number; endTs: number } => {
+  const resolvedYear = getDefaultTaxYear(taxYear);
+  const startYearStr = resolvedYear.split('-')[0];
+  const startYear = parseInt(startYearStr, 10);
+
+  // UK tax year: 6th April to 5th April
+  const startTs = new Date(startYear, 3, 6).getTime(); // Month 3 is April
+  const endTs = new Date(startYear + 1, 3, 5, 23, 59, 59, 999).getTime();
+
+  return { startTs, endTs };
+};

--- a/src/hooks/useTaxCalculations.ts
+++ b/src/hooks/useTaxCalculations.ts
@@ -5,6 +5,7 @@ import { useStore } from '@/store/useStore';
 import type { TaxCalculationInput } from '@/models/TaxCalculationInput';
 import type { TaxCalculationResult } from '@/models/TaxCalculationResult';
 import { calculateProjectedAnnualInterest } from '@/utils/interestCalculations';
+import { getTaxYearDates } from '@/constants/taxConstants';
 
 export interface UseTaxCalculationsResult {
     p1Incomes: { employment: number; pension: number; rental: number; dividends: number; interest: number };
@@ -43,6 +44,8 @@ export function useTaxCalculations(): UseTaxCalculationsResult {
         }
 
         if (dbAccounts) {
+            const { startTs, endTs } = getTaxYearDates(taxYear || undefined);
+
             dbAccounts.forEach(acc => {
                 const taxFreeCategories = ['Cash ISA', 'Shares ISA', 'Premium Bonds'];
                 if (acc.category && taxFreeCategories.includes(acc.category as string)) {
@@ -50,7 +53,7 @@ export function useTaxCalculations(): UseTaxCalculationsResult {
                 }
 
                 const accountAccruals = allAccruals.filter(a => a.accountId === acc.id);
-                const amount = calculateProjectedAnnualInterest(acc, accountAccruals);
+                const amount = calculateProjectedAnnualInterest(acc, accountAccruals, startTs, endTs);
 
                 if (acc.ownerId === 'person1') p1Incomes.interest += amount;
                 else if (acc.ownerId === 'person2') p2Incomes.interest += amount;

--- a/src/services/accountCalculations.test.ts
+++ b/src/services/accountCalculations.test.ts
@@ -94,15 +94,24 @@ describe('accountCalculations', () => {
             };
             const aerAccount = createMockAccount(1000, 5); // 1000 * 0.05 = 50
 
+            // To ensure 12 months remaining, we will set the latest date to exactly 12 months before tax year end.
+            // Let's explicitly pass a tax year to calculateBlendedRate so we know the end date.
+            // Using "2024-2025" tax year -> ends April 5, 2025.
+            const taxYearEnd = new Date(2025, 3, 5, 23, 59, 59, 999); // April 5, 2025
+            const twelveMonthsPrior = new Date(taxYearEnd.getFullYear() - 1, taxYearEnd.getMonth(), taxYearEnd.getDate());
+
             const accruals = [
-                { id: '1', accountId: 'acc1', date: 1000, balance: 2000, interestAccrued: 10 },
-                { id: '2', accountId: 'acc1', date: 2000, balance: 2000, interestAccrued: 15 } // latest
+                { id: '1', accountId: 'acc1', date: twelveMonthsPrior.getTime() - 100000, balance: 2000, interestAccrued: 10 },
+                { id: '2', accountId: 'acc1', date: twelveMonthsPrior.getTime(), balance: 2000, interestAccrued: 15 } // latest
             ];
-            // manualAccount projected interest: 15 * 12 = 180
-            // total interest: 180 + 50 = 230
+            // manualAccount actual interest so far: 10 + 15 = 25
+            // projected remaining: 15 * 12 months = 180
+            // total manual interest: 25 + 180 = 205
+            // aer account interest: 50
+            // total interest: 205 + 50 = 255
             // total balance: 2000 + 1000 = 3000
-            // rate: 230 / 3000 = 0.07666... = 7.666...%
-            expect(calculateBlendedRate([manualAccount, aerAccount], accruals)).toBeCloseTo(7.6667, 4);
+            // rate: 255 / 3000 = 0.085 = 8.5%
+            expect(calculateBlendedRate([manualAccount, aerAccount], accruals, '2024-2025')).toBeCloseTo(8.5, 4);
         });
     });
 });

--- a/src/services/accountCalculations.ts
+++ b/src/services/accountCalculations.ts
@@ -1,5 +1,6 @@
 import { type Account, type InterestAccrual } from '@/lib/db';
 import { calculateProjectedAnnualInterest } from '@/utils/interestCalculations';
+import { getTaxYearDates } from '@/constants/taxConstants';
 
 export function calculateTotalSavings(accounts: Account[]): number {
     return accounts.reduce((sum, acc) => sum + (acc.balance || 0), 0);
@@ -19,11 +20,14 @@ export function calculateTaxableSavings(accounts: Account[]): number {
     }, 0);
 }
 
-export function calculateBlendedRate(accounts: Account[], allAccruals: InterestAccrual[] = []): number {
+export function calculateBlendedRate(accounts: Account[], allAccruals: InterestAccrual[] = [], taxYear?: string): number {
     const totalSavingsValueForRate = accounts.reduce((sum, acc) => sum + (acc.balance || 0), 0);
+
+    const { startTs, endTs } = getTaxYearDates(taxYear);
+
     const totalInterestValue = accounts.reduce((sum, acc) => {
         const accountAccruals = allAccruals.filter(a => a.accountId === acc.id);
-        return sum + calculateProjectedAnnualInterest(acc, accountAccruals);
+        return sum + calculateProjectedAnnualInterest(acc, accountAccruals, startTs, endTs);
     }, 0);
 
     const blendedRateValue = totalSavingsValueForRate > 0 ? (totalInterestValue / totalSavingsValueForRate) * 100 : 0;

--- a/src/utils/interestCalculations.ts
+++ b/src/utils/interestCalculations.ts
@@ -1,19 +1,57 @@
 import type { Account, InterestAccrual } from '../lib/db';
 
-export const calculateProjectedAnnualInterest = (account: Account, accruals: InterestAccrual[] = []): number => {
+export const calculateProjectedAnnualInterest = (
+    account: Account,
+    currentYearAccruals: InterestAccrual[] = [],
+    taxYearStartTs: number,
+    taxYearEndTs: number
+): number => {
+    // 1. Determine the end of the runway for this tax year
+    // Safely fallback to taxYearEndTs if bonusEndDate is missing or falls outside this tax year
+    const runwayEndTs = (account.bonusEndDate && account.bonusEndDate < taxYearEndTs)
+        ? account.bonusEndDate
+        : taxYearEndTs;
+
+    // --- MANUAL TRACKING ---
     if (account.interestTrackingMethod === 'manual') {
-        if (!accruals || accruals.length === 0) return 0;
+        if (!currentYearAccruals || currentYearAccruals.length === 0) return 0;
 
-        // Find the most recent accrual to calculate the annual run-rate
-        const latestAccrual = accruals.reduce((latest, current) =>
-            current.date > latest.date ? current : latest
-        , accruals[0]);
+        const sortedAccruals = [...currentYearAccruals].sort((a, b) => a.date - b.date);
+        const latestAccrual = sortedAccruals[sortedAccruals.length - 1];
 
-        return (latestAccrual.interestAccrued || 0) * 12;
+        const actualInterestSoFar = sortedAccruals.reduce(
+            (sum, accrual) => sum + (accrual.interestAccrued || 0),
+            0
+        );
+
+        const latestDate = new Date(latestAccrual.date);
+        const endDate = new Date(runwayEndTs);
+
+        // Calculate remaining months. Will be <= 0 if the latest entry is past the runway end.
+        const monthsRemaining = (endDate.getFullYear() - latestDate.getFullYear()) * 12
+                              + (endDate.getMonth() - latestDate.getMonth());
+
+        const safeRemainingMonths = Math.max(0, monthsRemaining);
+        const projectedRemaining = (latestAccrual.interestAccrued || 0) * safeRemainingMonths;
+
+        return actualInterestSoFar + projectedRemaining;
     }
 
-    // Default AER calculation
+    // --- AUTOMATIC AER TRACKING ---
     const balance = account.balance || 0;
-    const rate = account.interestRate || 0;
-    return balance * (rate / 100);
+    const rate = (account.interestRate || 0) / 100;
+    const fullYearInterest = balance * rate;
+
+    // If there is no bonusEndDate, or it extends past the tax year, they get the full year AER.
+    if (!account.bonusEndDate || account.bonusEndDate >= taxYearEndTs) {
+        return fullYearInterest;
+    }
+
+    // If there IS a bonusEndDate that cuts off during the tax year, pro-rate the AER.
+    const start = new Date(taxYearStartTs);
+    const end = new Date(runwayEndTs);
+    const activeMonths = (end.getFullYear() - start.getFullYear()) * 12 + (end.getMonth() - start.getMonth());
+
+    const safeActiveMonths = Math.max(0, Math.min(12, activeMonths));
+    return (fullYearInterest / 12) * safeActiveMonths;
 };

--- a/test_plan.sh
+++ b/test_plan.sh
@@ -1,0 +1,1 @@
+grep -rn "calculateProjectedAnnualInterest" src/


### PR DESCRIPTION
This commit implements the refined projection logic for calculating annual interest on accounts. The single source of truth (the pure calculation) now bounds both AER and manual tracking models using tax year boundaries (`taxYearStartTs` and `taxYearEndTs`) while safely falling back or truncating to `bonusEndDate` when applicable. It successfully bridges this pure utility with the Dexie store dependencies.

---
*PR created automatically by Jules for task [3884206937720295003](https://jules.google.com/task/3884206937720295003) started by @John-Bell*