### PR TITLE
Rename Bonus End Date to Maturity Date

### DIFF
--- a/src/pages/AddAccountPage.tsx
+++ b/src/pages/AddAccountPage.tsx
@@ -200,7 +200,7 @@ export function AddAccountPage() {
 
                         {bonusRateActive && (
                             <div className="space-y-2 fade-in">
-                                <label className="block text-xs font-semibold uppercase tracking-wider text-slate-500 dark:text-slate-400">Bonus End Date</label>
+                                <label className="block text-xs font-semibold uppercase tracking-wider text-slate-500 dark:text-slate-400">Maturity Date</label>
                                 <div className="relative">
                                     <input
                                         className="w-full h-12 px-4 rounded-lg bg-white dark:bg-primary/10 border border-slate-200 dark:border-primary/20 focus:border-primary outline-none text-slate-900 dark:text-slate-100 dark:[color-scheme:dark]"

--- a/src/pages/EditAccountPage.tsx
+++ b/src/pages/EditAccountPage.tsx
@@ -270,7 +270,7 @@ export function EditAccountPage() {
 
                         {bonusRateActive && (
                             <div className="space-y-2 fade-in">
-                                <label className="block text-xs font-semibold uppercase tracking-wider text-slate-500 dark:text-slate-400">Bonus End Date</label>
+                                <label className="block text-xs font-semibold uppercase tracking-wider text-slate-500 dark:text-slate-400">Maturity Date</label>
                                 <div className="relative">
                                     <input
                                         className="w-full h-12 px-4 rounded-lg bg-white dark:bg-primary/10 border border-slate-200 dark:border-primary/20 focus:border-primary outline-none text-slate-900 dark:text-slate-100 dark:[color-scheme:dark]"


### PR DESCRIPTION
Changes references to "Bonus End Date" in the Add Account and Edit Account forms to say "Maturity Date".

This is a pure UI change. The underlying data model (`bonusEndDate`) and logic remain unaffected.

---
*PR created automatically by Jules for task [5917677339617270078](https://jules.google.com/task/5917677339617270078) started by @John-Bell*