### PR TITLE
Add interest payout fields to Account model and forms

### DIFF
--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -30,6 +30,8 @@ export interface Account {
     // --- Bonus Rate Fields ---
     bonusRateActive?: boolean;
     bonusEndDate?: number; // timestamp
+    interestPayoutFrequency?: 'monthly' | 'annually' | 'at_maturity';
+    interestPayoutDate?: number; // timestamp for next expected payout or maturity payout
     // --- Import Fields ---
     importId?: string;
     externalRef?: string;
@@ -249,6 +251,21 @@ db.version(6).stores({
     interestAccruals: '&id, accountId, date, updatedAt'
 });
 
+db.version(7).stores({
+    profile: '&id',
+    accounts: '&id, ownerId, name, category, importId, updatedAt',
+    incomes: '&id, ownerId, name, frequency, type, taxCategory, updatedAt',
+    scenarios: '&id, name, updatedAt',
+    settings: '&id',
+    monthlyArchives: '&id, month, year, updatedAt',
+    notifications: '&id, date, read, updatedAt',
+    taxRules: '&id, updatedAt',
+    budgets: '&id, accountId, name, importId, updatedAt',
+    transactions: '&id, date, type, budgetId, accountId, importId, updatedAt',
+    paymentMappings: '&id, paymentName, *budgetIds, updatedAt',
+    interestAccruals: '&id, accountId, date, updatedAt'
+});
+
 export const getSanitizedDbData = async (): Promise<Record<string, any[]>> => {
     const rawData = {
         profile: await db.profile.toArray(),
@@ -288,6 +305,7 @@ export const getSanitizedDbData = async (): Promise<Record<string, any[]>> => {
             balance: Number(a.balance) || 0,
             interestRate: Number(a.interestRate) || 0,
             budgetOrder: a.budgetOrder !== undefined ? Number(a.budgetOrder) : undefined,
+            interestPayoutDate: a.interestPayoutDate !== undefined ? Number(a.interestPayoutDate) : undefined,
         }));
     }
 

--- a/src/pages/AddAccountPage.tsx
+++ b/src/pages/AddAccountPage.tsx
@@ -27,6 +27,8 @@ export function AddAccountPage() {
     const [budgetOrder, setBudgetOrder] = useState('');
     const [bonusRateActive, setBonusRateActive] = useState(false);
     const [bonusEndDate, setBonusEndDate] = useState('');
+    const [payoutFrequency, setPayoutFrequency] = useState<'monthly' | 'annually' | 'at_maturity' | ''>('');
+    const [payoutDate, setPayoutDate] = useState('');
     const [ownerId, setOwnerId] = useState('joint'); // 'person1', 'person2', 'joint'
 
     const showAER = category === '' || !['Stocks & Shares', 'Shares ISA', 'DC Pension', 'Premium Bonds'].includes(category as string);
@@ -51,6 +53,10 @@ export function AddAccountPage() {
             bonusRateActive: showBonus ? bonusRateActive : false,
             // Convert 'YYYY-MM-DD' back to timestamp if active, else undefined
             bonusEndDate: showBonus && bonusRateActive && bonusEndDate ? new Date(bonusEndDate).getTime() : undefined,
+            interestPayoutFrequency: payoutFrequency || undefined,
+            interestPayoutDate: (payoutFrequency === 'annually' || payoutFrequency === 'at_maturity') && payoutDate
+                ? new Date(payoutDate).getTime()
+                : undefined,
             updatedAt: Date.now(),
         };
 
@@ -176,6 +182,43 @@ export function AddAccountPage() {
                             />
                             <span className="absolute right-4 text-slate-400 font-bold">%</span>
                         </div>
+                    </div>
+                )}
+
+                {/* Interest Payout Section */}
+                {showAER && parseFloat(interestRate) > 0 && (
+                    <div className="space-y-4 p-5 rounded-xl border border-primary/20 bg-primary/5">
+                        <h3 className="font-bold text-slate-900 dark:text-slate-100">Interest Payout</h3>
+                        <div className="space-y-2">
+                            <label className="block text-xs font-semibold text-slate-600 dark:text-slate-400">Frequency</label>
+                            <div className="relative">
+                                <select
+                                    className="w-full h-14 pl-4 pr-12 appearance-none text-slate-900 dark:text-slate-100 rounded-lg bg-white dark:bg-primary/10 border border-slate-200 dark:border-primary/20 focus:border-primary focus:ring-1 focus:ring-primary outline-none transition-all"
+                                    value={payoutFrequency}
+                                    onChange={(e) => setPayoutFrequency(e.target.value as 'monthly' | 'annually' | 'at_maturity' | '')}
+                                >
+                                    <option value="" disabled>Select Frequency</option>
+                                    <option value="monthly">Monthly</option>
+                                    <option value="annually">Annually</option>
+                                    <option value="at_maturity">At Maturity</option>
+                                </select>
+                                <span className="absolute right-4 top-1/2 -translate-y-1/2 material-symbols-outlined pointer-events-none text-slate-400">expand_more</span>
+                            </div>
+                        </div>
+
+                        {(payoutFrequency === 'annually' || payoutFrequency === 'at_maturity') && (
+                            <div className="space-y-2 fade-in">
+                                <label className="block text-xs font-semibold text-slate-600 dark:text-slate-400">Next Payout Date</label>
+                                <div className="relative">
+                                    <input
+                                        className="w-full h-12 px-4 rounded-lg bg-white dark:bg-primary/10 border border-slate-200 dark:border-primary/20 focus:border-primary outline-none text-slate-900 dark:text-slate-100 dark:[color-scheme:dark]"
+                                        type="date"
+                                        value={payoutDate}
+                                        onChange={(e) => setPayoutDate(e.target.value)}
+                                    />
+                                </div>
+                            </div>
+                        )}
                     </div>
                 )}
 

--- a/src/pages/EditAccountPage.tsx
+++ b/src/pages/EditAccountPage.tsx
@@ -26,6 +26,8 @@ export function EditAccountPage() {
     const [interestTrackingMethod, setInterestTrackingMethod] = useState<'aer' | 'manual'>('aer');
     const [bonusRateActive, setBonusRateActive] = useState(false);
     const [bonusEndDate, setBonusEndDate] = useState('');
+    const [payoutFrequency, setPayoutFrequency] = useState<'monthly' | 'annually' | 'at_maturity' | ''>('');
+    const [payoutDate, setPayoutDate] = useState('');
     const [ownerId, setOwnerId] = useState('joint');
 
     const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
@@ -48,6 +50,16 @@ export function EditAccountPage() {
                 const month = String(date.getMonth() + 1).padStart(2, '0');
                 const day = String(date.getDate()).padStart(2, '0');
                 setBonusEndDate(`${year}-${month}-${day}`);
+            }
+            setPayoutFrequency(account.interestPayoutFrequency || '');
+            if (account.interestPayoutDate) {
+                const pDate = new Date(account.interestPayoutDate);
+                const pYear = pDate.getFullYear();
+                const pMonth = String(pDate.getMonth() + 1).padStart(2, '0');
+                const pDay = String(pDate.getDate()).padStart(2, '0');
+                setPayoutDate(`${pYear}-${pMonth}-${pDay}`);
+            } else {
+                setPayoutDate('');
             }
             setOwnerId(account.ownerId);
         }
@@ -80,6 +92,10 @@ export function EditAccountPage() {
                 budgetOrder: budgetOrder !== '' ? parseInt(budgetOrder, 10) : undefined,
                 bonusRateActive: showBonus ? bonusRateActive : false,
                 bonusEndDate: showBonus && bonusRateActive && bonusEndDate ? new Date(bonusEndDate).getTime() : undefined,
+                interestPayoutFrequency: payoutFrequency || undefined,
+                interestPayoutDate: (payoutFrequency === 'annually' || payoutFrequency === 'at_maturity') && payoutDate
+                    ? new Date(payoutDate).getTime()
+                    : undefined,
                 ownerId,
                 updatedAt: Date.now(),
             });
@@ -248,6 +264,43 @@ export function EditAccountPage() {
                         </div>
                     )}
                 </div>
+
+                {/* Interest Payout Section */}
+                {isEligibleForAER && interestTrackingMethod === 'aer' && parseFloat(interestRate) > 0 && (
+                    <div className="space-y-4 p-5 rounded-xl border border-primary/20 bg-primary/5">
+                        <h3 className="font-bold text-slate-900 dark:text-slate-100">Interest Payout</h3>
+                        <div className="space-y-2">
+                            <label className="block text-xs font-semibold text-slate-600 dark:text-slate-400">Frequency</label>
+                            <div className="relative">
+                                <select
+                                    className="w-full h-14 pl-4 pr-12 appearance-none text-slate-900 dark:text-slate-100 rounded-lg bg-white dark:bg-primary/10 border border-slate-200 dark:border-primary/20 focus:border-primary focus:ring-1 focus:ring-primary outline-none transition-all"
+                                    value={payoutFrequency}
+                                    onChange={(e) => setPayoutFrequency(e.target.value as 'monthly' | 'annually' | 'at_maturity' | '')}
+                                >
+                                    <option value="" disabled>Select Frequency</option>
+                                    <option value="monthly">Monthly</option>
+                                    <option value="annually">Annually</option>
+                                    <option value="at_maturity">At Maturity</option>
+                                </select>
+                                <span className="absolute right-4 top-1/2 -translate-y-1/2 material-symbols-outlined pointer-events-none text-slate-400">expand_more</span>
+                            </div>
+                        </div>
+
+                        {(payoutFrequency === 'annually' || payoutFrequency === 'at_maturity') && (
+                            <div className="space-y-2 fade-in">
+                                <label className="block text-xs font-semibold text-slate-600 dark:text-slate-400">Next Payout Date</label>
+                                <div className="relative">
+                                    <input
+                                        className="w-full h-12 px-4 rounded-lg bg-white dark:bg-primary/10 border border-slate-200 dark:border-primary/20 focus:border-primary outline-none text-slate-900 dark:text-slate-100 dark:[color-scheme:dark]"
+                                        type="date"
+                                        value={payoutDate}
+                                        onChange={(e) => setPayoutDate(e.target.value)}
+                                    />
+                                </div>
+                            </div>
+                        )}
+                    </div>
+                )}
 
                 {/* Bonus Rate Section */}
                 {showBonus && (


### PR DESCRIPTION
Update the Account data model and `AddAccountPage`/`EditAccountPage` to track when interest is actually paid out (`interestPayoutFrequency` and `interestPayoutDate`). This is needed for tax forecasting. Only visible for AER accounts with non-zero interest rates. Bumps Dexie db version.

---
*PR created automatically by Jules for task [11556350848319986242](https://jules.google.com/task/11556350848319986242) started by @John-Bell*