### PR TITLE
Fix Bonus End Date Label and Support Fixed Term Savings

### DIFF
--- a/src/pages/AddAccountPage.tsx
+++ b/src/pages/AddAccountPage.tsx
@@ -32,7 +32,7 @@ export function AddAccountPage() {
     const [ownerId, setOwnerId] = useState('joint'); // 'person1', 'person2', 'joint'
 
     const showAER = category === '' || !['Stocks & Shares', 'Shares ISA', 'DC Pension', 'Premium Bonds'].includes(category as string);
-    const showBonus = category === '' || ['Easy Access Savings', 'Cash ISA', 'Current Account'].includes(category as string);
+    const showBonus = category === '' || ['Easy Access Savings', 'Cash ISA', 'Current Account', 'Fixed Term Savings'].includes(category as string);
 
     const handleSave = async () => {
         if (!accountName || !balance || !category) return;
@@ -243,7 +243,7 @@ export function AddAccountPage() {
 
                         {bonusRateActive && (
                             <div className="space-y-2 fade-in">
-                                <label className="block text-xs font-semibold uppercase tracking-wider text-slate-500 dark:text-slate-400">Maturity Date</label>
+                                <label className="block text-xs font-semibold uppercase tracking-wider text-slate-500 dark:text-slate-400">Bonus End Date</label>
                                 <div className="relative">
                                     <input
                                         className="w-full h-12 px-4 rounded-lg bg-white dark:bg-primary/10 border border-slate-200 dark:border-primary/20 focus:border-primary outline-none text-slate-900 dark:text-slate-100 dark:[color-scheme:dark]"

--- a/src/pages/EditAccountPage.tsx
+++ b/src/pages/EditAccountPage.tsx
@@ -66,7 +66,7 @@ export function EditAccountPage() {
     }, [account]);
 
     const isEligibleForAER = category === '' || !['Stocks & Shares', 'Shares ISA', 'DC Pension', 'Premium Bonds'].includes(category as string);
-    const showBonus = category === '' || ['Easy Access Savings', 'Cash ISA', 'Current Account'].includes(category as string);
+    const showBonus = category === '' || ['Easy Access Savings', 'Cash ISA', 'Current Account', 'Fixed Term Savings'].includes(category as string);
 
     useEffect(() => {
         if (!isEligibleForAER && interestTrackingMethod !== 'manual') {
@@ -323,7 +323,7 @@ export function EditAccountPage() {
 
                         {bonusRateActive && (
                             <div className="space-y-2 fade-in">
-                                <label className="block text-xs font-semibold uppercase tracking-wider text-slate-500 dark:text-slate-400">Maturity Date</label>
+                                <label className="block text-xs font-semibold uppercase tracking-wider text-slate-500 dark:text-slate-400">Bonus End Date</label>
                                 <div className="relative">
                                     <input
                                         className="w-full h-12 px-4 rounded-lg bg-white dark:bg-primary/10 border border-slate-200 dark:border-primary/20 focus:border-primary outline-none text-slate-900 dark:text-slate-100 dark:[color-scheme:dark]"


### PR DESCRIPTION
Fixes an issue where the Bonus End Date was incorrectly labelled as "Maturity Date" on Add and Edit Account forms. Also updates the conditional rendering logic to display the Bonus Rate section for accounts categorized as "Fixed Term Savings".

---
*PR created automatically by Jules for task [16808511821538460634](https://jules.google.com/task/16808511821538460634) started by @John-Bell*