### PR TITLE
Add Total Tax row to IncomesPage

### DIFF
--- a/src/hooks/useTaxCalculations.ts
+++ b/src/hooks/useTaxCalculations.ts
@@ -15,6 +15,7 @@ export interface UseTaxCalculationsResult {
     p1TotalIncome: number;
     p2TotalIncome: number;
     combinedNet: number;
+    combinedTotalTax: number;
     combinedEffectiveRate: number;
     isReady: boolean;
 }
@@ -113,6 +114,7 @@ export function useTaxCalculations(): UseTaxCalculationsResult {
             p1TotalIncome,
             p2TotalIncome,
             combinedNet,
+            combinedTotalTax,
             combinedEffectiveRate,
             isReady: !!dbAccounts && !!dbIncomes && !!taxService
         };

--- a/src/pages/IncomePage.tsx
+++ b/src/pages/IncomePage.tsx
@@ -133,6 +133,11 @@ export function IncomePage() {
                                     <td className="px-4 py-4 text-right">{formatCurr(p2Total)}</td>
                                 </tr>
                                 <tr className="border-t border-slate-200 dark:border-primary/10">
+                                    <td className="px-4 py-4 text-red-500">Total Tax</td>
+                                    <td className="px-4 py-4 text-right text-red-500">{formatCurr(p1TaxResult?.totalTax || 0)}</td>
+                                    <td className="px-4 py-4 text-right text-red-500">{formatCurr(p2TaxResult?.totalTax || 0)}</td>
+                                </tr>
+                                <tr className="border-t border-slate-200 dark:border-primary/10">
                                     <td className="px-4 py-4 text-primary">Combined Net</td>
                                     <td colSpan={2} className="px-4 py-4 text-right text-primary text-lg">{formatCurr(combinedNet)}</td>
                                 </tr>


### PR DESCRIPTION
- Extracted `combinedTotalTax` in `useTaxCalculations` (though ultimately opting to display individual tax amounts on the UI for clarity and consistency with the Total Gross row).
- Modified `IncomePage.tsx` table footer (`<tfoot />`) to include the "Total Tax" row, with values sourced from `p1TaxResult?.totalTax` and `p2TaxResult?.totalTax`.
- Ensured currency formatting and visual consistency.
- Fixed unused variable TS warning.
- Ran tests and build to ensure no regressions.

---
*PR created automatically by Jules for task [2611158002753403579](https://jules.google.com/task/2611158002753403579) started by @John-Bell*