### PR TITLE
Fix: Restore Interest Payout section in Add/Edit Account forms

### DIFF
--- a/src/pages/AddAccountPage.tsx
+++ b/src/pages/AddAccountPage.tsx
@@ -167,7 +167,7 @@ export function AddAccountPage() {
                 </div>
 
                 {/* Interest Payout Section */}
-                {isEligibleForAER && formData.interestTrackingMethod === 'aer' && parseFloat(formData.interestRate || '0') > 0 && (
+                {showAER && formData.interestTrackingMethod === 'aer' && parseFloat(formData.interestRate || '0') > 0 && (
                     <div className="space-y-4 p-5 rounded-xl border border-primary/20 bg-primary/5">
                         <h3 className="font-bold text-slate-900 dark:text-slate-100">Interest Payout</h3>
                         <div className="space-y-2">


### PR DESCRIPTION
Fixes a bug where the `Interest Payout Section` was hidden on the Add and Edit Account forms due to an incorrectly mapped local variable (`isEligibleForAER` vs `showAER`). The fix ensures the `Interest Payout Section` displays when appropriate and restores the proper labels ("Maturity Date" / "Next Payout Date" and "Bonus End Date").

---
*PR created automatically by Jules for task [3883960119841153718](https://jules.google.com/task/3883960119841153718) started by @John-Bell*