### PR TITLE
Fix Interest Payout visibility in Account forms

### DIFF
--- a/src/pages/AddAccountPage.tsx
+++ b/src/pages/AddAccountPage.tsx
@@ -167,7 +167,7 @@ export function AddAccountPage() {
                 </div>
 
                 {/* Interest Payout Section */}
-                {showAER && formData.interestTrackingMethod === 'aer' && (
+                {showAER && (
                     <div className="space-y-4 p-5 rounded-xl border border-primary/20 bg-primary/5">
                         <h3 className="font-bold text-slate-900 dark:text-slate-100">Interest Payout</h3>
                         <div className="space-y-2">

--- a/src/pages/EditAccountPage.tsx
+++ b/src/pages/EditAccountPage.tsx
@@ -172,7 +172,7 @@ export function EditAccountPage() {
                 </div>
 
                 {/* Interest Payout Section */}
-                {isEligibleForAER && formData.interestTrackingMethod === 'aer' && (
+                {isEligibleForAER && (
                     <div className="space-y-4 p-5 rounded-xl border border-primary/20 bg-primary/5">
                         <h3 className="font-bold text-slate-900 dark:text-slate-100">Interest Payout</h3>
                         <div className="space-y-2">


### PR DESCRIPTION
This commit removes the restriction that required the calculation method to be strictly 'aer' in order to display the Interest Payout section. It updates `AddAccountPage` and `EditAccountPage` so the payout details (frequency and next payout date) remain visible and configurable for manual ledger accounts that are eligible for AER.

---
*PR created automatically by Jules for task [17261295881763939598](https://jules.google.com/task/17261295881763939598) started by @John-Bell*