### PR TITLE
Fix manual ledger saving bug on account forms

### DIFF
--- a/src/hooks/useAccountForm.ts
+++ b/src/hooks/useAccountForm.ts
@@ -49,6 +49,8 @@ export function useAccountForm(accountId?: string) {
 
     const [formData, setFormData] = useState<AccountFormData>(defaultFormData);
     const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
+    const [draftId] = useState(() => crypto.randomUUID());
+    const activeAccountId = accountId || draftId;
 
     useEffect(() => {
         if (account) {
@@ -130,7 +132,7 @@ export function useAccountForm(accountId?: string) {
             } else {
                 await db.accounts.add({
                     ...accountData,
-                    id: crypto.randomUUID(),
+                    id: activeAccountId,
                 } as Account);
             }
             navigate('/accounts');
@@ -151,6 +153,7 @@ export function useAccountForm(accountId?: string) {
 
     return {
         account,
+        activeAccountId,
         navigate,
         p1Name,
         p2Name,

--- a/src/pages/AddAccountPage.tsx
+++ b/src/pages/AddAccountPage.tsx
@@ -5,6 +5,7 @@ import { useAccountForm } from '@/hooks/useAccountForm';
 
 export function AddAccountPage() {
     const {
+        activeAccountId,
         navigate,
         p1Name,
         p2Name,
@@ -277,7 +278,7 @@ export function AddAccountPage() {
 
                 {formData.interestTrackingMethod === 'manual' && (
                     <aside className="w-full xl:w-[calc(60%-1rem)]">
-                        <InterestLedger accountId="temp-new-account" currentBalance={parseFloat(formData.balance) || 0} />
+                        <InterestLedger accountId={activeAccountId} currentBalance={parseFloat(formData.balance) || 0} />
                     </aside>
                 )}
             </div>

--- a/src/pages/EditAccountPage.tsx
+++ b/src/pages/EditAccountPage.tsx
@@ -8,6 +8,7 @@ export function EditAccountPage() {
     const { id } = useParams<{ id: string }>();
     const {
         account,
+        activeAccountId,
         navigate,
         p1Name,
         p2Name,
@@ -282,7 +283,7 @@ export function EditAccountPage() {
 
                 {formData.interestTrackingMethod === 'manual' && (
                     <aside className="w-full xl:w-[calc(60%-1rem)]">
-                        <InterestLedger accountId={account?.id || ''} currentBalance={parseFloat(formData.balance) || 0} />
+                        <InterestLedger accountId={activeAccountId} currentBalance={parseFloat(formData.balance) || 0} />
                     </aside>
                 )}
             </div>


### PR DESCRIPTION
Fix issue where adding manual ledger on new account screen was not being retrieved because it wasn't linked to the proper account ID. Update `useAccountForm` to use a `draftId` which correctly links manually added ledger entries to the new account UUID.

---
*PR created automatically by Jules for task [8603612762900570603](https://jules.google.com/task/8603612762900570603) started by @John-Bell*