### PR TITLE
Fix iOS date input rendering

### DIFF
--- a/src/pages/AddAccountPage.tsx
+++ b/src/pages/AddAccountPage.tsx
@@ -189,13 +189,13 @@ export function AddAccountPage() {
                         </div>
 
                         {(formData.interestPayoutFrequency === 'annually' || formData.interestPayoutFrequency === 'at_maturity') && (
-                            <div className="space-y-2 fade-in">
+                            <div className="space-y-2 fade-in min-w-0 w-full">
                                 <label className="block text-xs font-semibold text-slate-600 dark:text-slate-400">
                                     {formData.interestPayoutFrequency === 'at_maturity' ? 'Maturity Date' : 'Next Payout Date'}
                                 </label>
-                                <div className="relative">
+                                <div className="relative min-w-0 w-full">
                                     <input
-                                        className="w-full h-12 px-4 rounded-lg bg-white dark:bg-primary/10 border border-slate-200 dark:border-primary/20 focus:border-primary outline-none text-slate-900 dark:text-slate-100 dark:[color-scheme:dark]"
+                                        className="w-full h-12 px-4 rounded-lg bg-white dark:bg-primary/10 border border-slate-200 dark:border-primary/20 focus:border-primary outline-none text-slate-900 dark:text-slate-100 dark:[color-scheme:dark] block max-w-full appearance-none min-w-0"
                                         type="date"
                                         value={formData.interestPayoutDate}
                                         onChange={(e) => handleChange('interestPayoutDate', e.target.value)}
@@ -226,11 +226,11 @@ export function AddAccountPage() {
                         </div>
 
                         {formData.bonusRateActive && (
-                            <div className="space-y-2 fade-in">
+                            <div className="space-y-2 fade-in min-w-0 w-full">
                                 <label className="block text-xs font-semibold uppercase tracking-wider text-slate-500 dark:text-slate-400">Bonus End Date</label>
-                                <div className="relative">
+                                <div className="relative min-w-0 w-full">
                                     <input
-                                        className="w-full h-12 px-4 rounded-lg bg-white dark:bg-primary/10 border border-slate-200 dark:border-primary/20 focus:border-primary outline-none text-slate-900 dark:text-slate-100 dark:[color-scheme:dark]"
+                                        className="w-full h-12 px-4 rounded-lg bg-white dark:bg-primary/10 border border-slate-200 dark:border-primary/20 focus:border-primary outline-none text-slate-900 dark:text-slate-100 dark:[color-scheme:dark] block max-w-full appearance-none min-w-0"
                                         type="date"
                                         value={formData.bonusEndDate}
                                         onChange={(e) => handleChange('bonusEndDate', e.target.value)}

--- a/src/pages/AddPaymentPage.tsx
+++ b/src/pages/AddPaymentPage.tsx
@@ -207,14 +207,14 @@ export function AddPaymentPage() {
                         </div>
                     </div>
 
-                    <div>
+                    <div className="min-w-0 w-full">
                         <label className="block text-sm font-semibold text-slate-700 dark:text-slate-300 mb-1.5">Date</label>
                         <input
                             type="date"
                             required
                             value={date}
                             onChange={(e) => setDate(e.target.value)}
-                            className="w-full bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl px-4 py-3 text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary transition-colors"
+                            className="w-full bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl px-4 py-3 text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary transition-colors block max-w-full appearance-none min-w-0 dark:[color-scheme:dark]"
                         />
                     </div>
 

--- a/src/pages/EditAccountPage.tsx
+++ b/src/pages/EditAccountPage.tsx
@@ -194,13 +194,13 @@ export function EditAccountPage() {
                         </div>
 
                         {(formData.interestPayoutFrequency === 'annually' || formData.interestPayoutFrequency === 'at_maturity') && (
-                            <div className="space-y-2 fade-in">
+                            <div className="space-y-2 fade-in min-w-0 w-full">
                                 <label className="block text-xs font-semibold text-slate-600 dark:text-slate-400">
                                     {formData.interestPayoutFrequency === 'at_maturity' ? 'Maturity Date' : 'Next Payout Date'}
                                 </label>
-                                <div className="relative">
+                                <div className="relative min-w-0 w-full">
                                     <input
-                                        className="w-full h-12 px-4 rounded-lg bg-white dark:bg-primary/10 border border-slate-200 dark:border-primary/20 focus:border-primary outline-none text-slate-900 dark:text-slate-100 dark:[color-scheme:dark]"
+                                        className="w-full h-12 px-4 rounded-lg bg-white dark:bg-primary/10 border border-slate-200 dark:border-primary/20 focus:border-primary outline-none text-slate-900 dark:text-slate-100 dark:[color-scheme:dark] block max-w-full appearance-none min-w-0"
                                         type="date"
                                         value={formData.interestPayoutDate}
                                         onChange={(e) => handleChange('interestPayoutDate', e.target.value)}
@@ -231,11 +231,11 @@ export function EditAccountPage() {
                         </div>
 
                         {formData.bonusRateActive && (
-                            <div className="space-y-2 fade-in">
+                            <div className="space-y-2 fade-in min-w-0 w-full">
                                 <label className="block text-xs font-semibold uppercase tracking-wider text-slate-500 dark:text-slate-400">Bonus End Date</label>
-                                <div className="relative">
+                                <div className="relative min-w-0 w-full">
                                     <input
-                                        className="w-full h-12 px-4 rounded-lg bg-white dark:bg-primary/10 border border-slate-200 dark:border-primary/20 focus:border-primary outline-none text-slate-900 dark:text-slate-100 dark:[color-scheme:dark]"
+                                        className="w-full h-12 px-4 rounded-lg bg-white dark:bg-primary/10 border border-slate-200 dark:border-primary/20 focus:border-primary outline-none text-slate-900 dark:text-slate-100 dark:[color-scheme:dark] block max-w-full appearance-none min-w-0"
                                         type="date"
                                         value={formData.bonusEndDate}
                                         onChange={(e) => handleChange('bonusEndDate', e.target.value)}

--- a/src/pages/EditPaymentPage.tsx
+++ b/src/pages/EditPaymentPage.tsx
@@ -178,14 +178,14 @@ export function EditPaymentPage() {
                         </div>
                     </div>
 
-                    <div>
+                    <div className="min-w-0 w-full">
                         <label className="block text-sm font-semibold text-slate-700 dark:text-slate-300 mb-1.5">Date</label>
                         <input
                             type="date"
                             required
                             value={date}
                             onChange={(e) => setDate(e.target.value)}
-                            className="w-full bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl px-4 py-3 text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary transition-colors"
+                            className="w-full bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl px-4 py-3 text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary transition-colors block max-w-full appearance-none min-w-0 dark:[color-scheme:dark]"
                         />
                     </div>
 

--- a/test-results/.last-run.json
+++ b/test-results/.last-run.json
@@ -1,4 +1,0 @@
-{
-  "status": "passed",
-  "failedTests": []
-}


### PR DESCRIPTION
Adds `min-w-0`, `w-full`, `max-w-full`, and `appearance-none` Tailwind utility classes to native HTML date input fields in AddAccountPage, EditAccountPage, AddPaymentPage, and EditPaymentPage to resolve iOS Safari layout and styling bugs.

---
*PR created automatically by Jules for task [16735704224761652486](https://jules.google.com/task/16735704224761652486) started by @John-Bell*