### PR TITLE
Fix missing interest accrual sync and backup

### DIFF
--- a/src/services/backupService.ts
+++ b/src/services/backupService.ts
@@ -90,7 +90,7 @@ export const importDatabase = async () => {
         const tables = [
             'profile', 'accounts', 'incomes', 'scenarios', 'settings',
             'monthlyArchives', 'notifications', 'taxRules', 'transactions', 'budgets',
-            'paymentMappings'
+            'paymentMappings', 'interestAccruals'
         ];
         const dexieTables = tables.map(t => (db as any)[t]);
 

--- a/src/services/remoteSyncService.ts
+++ b/src/services/remoteSyncService.ts
@@ -34,9 +34,9 @@ async function deriveKey(passphrase: string, salt: Uint8Array): Promise<CryptoKe
 
 export async function mergeData(cloudData: Record<string, any[]>): Promise<boolean> {
     let hasLocalChanges = false;
-    const tables = ['profile', 'accounts', 'incomes', 'scenarios', 'settings', 'monthlyArchives', 'notifications', 'taxRules', 'transactions', 'budgets', 'paymentMappings'];
+    const tables = ['profile', 'accounts', 'incomes', 'scenarios', 'settings', 'monthlyArchives', 'notifications', 'taxRules', 'transactions', 'budgets', 'paymentMappings', 'interestAccruals'];
 
-    const tableList = [db.profile, db.accounts, db.incomes, db.scenarios, db.settings, db.monthlyArchives, db.notifications, db.taxRules, db.transactions, db.budgets, db.paymentMappings];
+    const tableList = [db.profile, db.accounts, db.incomes, db.scenarios, db.settings, db.monthlyArchives, db.notifications, db.taxRules, db.transactions, db.budgets, db.paymentMappings, db.interestAccruals];
 
     dbHooks.isSyncing = true;
     await db.transaction('rw', tableList, async () => {


### PR DESCRIPTION
Added `interestAccruals` table to the explicit list of tables to include during `mergeData` in remote synchronization and `importDatabase` in the backup service. This ensures manual interest ledger data is properly carried over and merged between devices and backups.

Tests passing, artifacts removed.

---
*PR created automatically by Jules for task [5943272288578996076](https://jules.google.com/task/5943272288578996076) started by @John-Bell*