### PR TITLE
feat: change accounts page tabs to show total taxable interest

### DIFF
--- a/src/pages/AccountsPage.tsx
+++ b/src/pages/AccountsPage.tsx
@@ -5,7 +5,7 @@ import { useLiveQuery } from 'dexie-react-hooks';
 import { db } from '@/lib/db';
 import { useStore } from '@/store/useStore';
 import { formatRelativeTime } from '@/lib/utils';
-import { calculateTotalSavings, calculateNonPensionSavings, calculateTaxableSavings } from '@/services/accountCalculations';
+import { calculateTotalSavings, calculateNonPensionSavings, calculateTaxableSavings, calculateTaxableInterest } from '@/services/accountCalculations';
 import { AppLayout } from '../components/layout/AppLayout';
 import { Header } from '../components/layout/Header';
 import { Icon } from '../components/ui/Icon';
@@ -15,13 +15,14 @@ import { MainHeaderActions } from '../components/layout/MainHeaderActions';
 
 export function AccountsPage() {
     const navigate = useNavigate();
-    const { profile, activeAccountsTab, setActiveAccountsTab } = useStore();
+    const { profile, activeAccountsTab, setActiveAccountsTab, taxYear } = useStore();
     const p1Name = profile?.partner1Name || 'Partner 1';
     const p2Name = profile?.partner2Name || 'Partner 2';
 
     const [sortBy, setSortBy] = useState<'rate' | 'name'>('rate');
 
     const rawAccounts = useLiveQuery(() => db.accounts.toArray()) || [];
+    const allAccruals = useLiveQuery(() => db.interestAccruals.toArray()) || [];
 
     const sortedRawAccounts = [...rawAccounts].sort((a, b) => {
         if (sortBy === 'rate') {
@@ -124,13 +125,13 @@ export function AccountsPage() {
                 <div className="flex bg-slate-100 dark:bg-black/20 p-1 rounded-xl mb-4 text-sm font-medium border border-black/5 dark:border-white/5">
                     {['person1', 'person2', 'joint'].map((tab) => {
                         const tabAccounts = rawAccounts.filter(acc => acc.ownerId === tab);
-                        const tabTaxable = calculateTaxableSavings(tabAccounts);
-                        const formattedTabTaxable = new Intl.NumberFormat('en-GB', {
+                        const tabTaxableInterest = calculateTaxableInterest(tabAccounts, allAccruals, taxYear || undefined);
+                        const formattedTabTaxableInterest = new Intl.NumberFormat('en-GB', {
                             style: 'currency',
                             currency: 'GBP',
                             minimumFractionDigits: 2,
                             maximumFractionDigits: 2
-                        }).format(tabTaxable);
+                        }).format(tabTaxableInterest);
 
                         return (
                             <button
@@ -142,7 +143,7 @@ export function AccountsPage() {
                                     }`}
                             >
                                 <div className="font-semibold">{tab === 'joint' ? 'Joint' : (tab === 'person1' ? p1Name : p2Name)}</div>
-                                <div className="text-xs font-normal opacity-80 mt-0.5">{formattedTabTaxable}</div>
+                                <div className="text-xs font-normal opacity-80 mt-0.5">{formattedTabTaxableInterest}</div>
                             </button>
                         );
                     })}

--- a/src/services/accountCalculations.test.ts
+++ b/src/services/accountCalculations.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { calculateTotalSavings, calculateBlendedRate, calculateTaxableSavings } from './accountCalculations';
+import { calculateTotalSavings, calculateBlendedRate, calculateTaxableSavings, calculateTaxableInterest } from './accountCalculations';
 import { type Account } from '@/lib/db';
 
 describe('accountCalculations', () => {
@@ -161,5 +161,69 @@ describe('calculateTaxableSavings', () => {
             { id: '5', name: 'Acc 5', balance: 300, ownerId: 'p1', updatedAt: 0, category: 'Fixed Term Savings', interestRate: 0 },
         ];
         expect(calculateTaxableSavings(accounts)).toBe(400);
+    });
+});
+
+describe('calculateTaxableInterest', () => {
+    it('returns 0 when accounts is empty', () => {
+        expect(calculateTaxableInterest([])).toBe(0);
+    });
+
+    it('calculates interest for non-excluded categories', () => {
+        const accounts: Account[] = [
+            { id: '1', name: 'Acc 1', balance: 1000, ownerId: 'p1', updatedAt: 0, category: 'Current Account', interestRate: 5 },
+            { id: '2', name: 'Acc 2', balance: 2000, ownerId: 'p2', updatedAt: 0, category: 'Easy Access Savings', interestRate: 2 },
+        ];
+        // 1000 * 0.05 = 50
+        // 2000 * 0.02 = 40
+        // Total = 90
+        expect(calculateTaxableInterest(accounts)).toBeCloseTo(90, 4);
+    });
+
+    it('excludes DC Pension accounts from interest calculation', () => {
+        const accounts: Account[] = [
+            { id: '1', name: 'Acc 1', balance: 1000, ownerId: 'p1', updatedAt: 0, category: 'Current Account', interestRate: 5 },
+            { id: '2', name: 'Acc 2', balance: 5000, ownerId: 'p2', updatedAt: 0, category: 'DC Pension', interestRate: 10 },
+        ];
+        expect(calculateTaxableInterest(accounts)).toBeCloseTo(50, 4);
+    });
+
+    it('excludes Premium Bonds accounts from interest calculation', () => {
+        const accounts: Account[] = [
+            { id: '1', name: 'Acc 1', balance: 1000, ownerId: 'p1', updatedAt: 0, category: 'Current Account', interestRate: 5 },
+            { id: '2', name: 'Acc 2', balance: 5000, ownerId: 'p2', updatedAt: 0, category: 'Premium Bonds', interestRate: 10 },
+        ];
+        expect(calculateTaxableInterest(accounts)).toBeCloseTo(50, 4);
+    });
+
+    it('excludes Cash ISA accounts from interest calculation', () => {
+        const accounts: Account[] = [
+            { id: '1', name: 'Acc 1', balance: 1000, ownerId: 'p1', updatedAt: 0, category: 'Current Account', interestRate: 5 },
+            { id: '2', name: 'Acc 2', balance: 5000, ownerId: 'p2', updatedAt: 0, category: 'Cash ISA', interestRate: 10 },
+        ];
+        expect(calculateTaxableInterest(accounts)).toBeCloseTo(50, 4);
+    });
+
+    it('excludes Shares ISA accounts from interest calculation', () => {
+        const accounts: Account[] = [
+            { id: '1', name: 'Acc 1', balance: 1000, ownerId: 'p1', updatedAt: 0, category: 'Current Account', interestRate: 5 },
+            { id: '2', name: 'Acc 2', balance: 5000, ownerId: 'p2', updatedAt: 0, category: 'Shares ISA', interestRate: 10 },
+        ];
+        expect(calculateTaxableInterest(accounts)).toBeCloseTo(50, 4);
+    });
+
+    it('excludes a mix of excluded categories and includes valid ones', () => {
+        const accounts: Account[] = [
+            { id: '1', name: 'Acc 1', balance: 1000, ownerId: 'p1', updatedAt: 0, category: 'Current Account', interestRate: 5 },
+            { id: '2', name: 'Acc 2', balance: 5000, ownerId: 'p2', updatedAt: 0, category: 'DC Pension', interestRate: 10 },
+            { id: '3', name: 'Acc 3', balance: 1000, ownerId: 'p2', updatedAt: 0, category: 'Premium Bonds', interestRate: 10 },
+            { id: '4', name: 'Acc 4', balance: 2000, ownerId: 'p2', updatedAt: 0, category: 'Cash ISA', interestRate: 10 },
+            { id: '5', name: 'Acc 5', balance: 3000, ownerId: 'p1', updatedAt: 0, category: 'Fixed Term Savings', interestRate: 2 },
+            { id: '6', name: 'Acc 6', balance: 1000, ownerId: 'p1', updatedAt: 0, category: 'Shares ISA', interestRate: 10 },
+        ];
+        // 1000 * 0.05 = 50
+        // 3000 * 0.02 = 60
+        // Total = 110
+        expect(calculateTaxableInterest(accounts)).toBeCloseTo(110, 4);
     });
 });

--- a/src/services/accountCalculations.ts
+++ b/src/services/accountCalculations.ts
@@ -20,6 +20,19 @@ export function calculateTaxableSavings(accounts: Account[]): number {
     }, 0);
 }
 
+export function calculateTaxableInterest(accounts: Account[], allAccruals: InterestAccrual[] = [], taxYear?: string): number {
+    const excludedCategories = ['DC Pension', 'Premium Bonds', 'Cash ISA', 'Shares ISA'];
+    const { startTs, endTs } = getTaxYearDates(taxYear);
+
+    return accounts.reduce((sum, acc) => {
+        if (acc.category && excludedCategories.includes(acc.category)) {
+            return sum;
+        }
+        const accountAccruals = allAccruals.filter(a => a.accountId === acc.id);
+        return sum + calculateProjectedAnnualInterest(acc, accountAccruals, startTs, endTs);
+    }, 0);
+}
+
 export function calculateBlendedRate(accounts: Account[], allAccruals: InterestAccrual[] = [], taxYear?: string): number {
     const totalSavingsValueForRate = accounts.reduce((sum, acc) => sum + (acc.balance || 0), 0);
 


### PR DESCRIPTION
This change updates the Accounts page to display the 'Total Taxable Interest' per person inside the owner tabs instead of 'Total non Pensions Savings'. 

It includes:
1. A new pure calculation function `calculateTaxableInterest` that projects interest for all accounts, excluding tax-exempt categories (DC Pension, Cash ISA, Shares ISA, Premium Bonds).
2. UI updates in `AccountsPage.tsx` to render the correct calculated values.
3. Unit tests in `accountCalculations.test.ts` to ensure the logic correctly filters out the untaxed accounts.

---
*PR created automatically by Jules for task [12236496698310730285](https://jules.google.com/task/12236496698310730285) started by @John-Bell*