### PR TITLE
fix: bypass cache for remote sync fetch requests

### DIFF
--- a/src/pages/RemoteSyncingPage.tsx
+++ b/src/pages/RemoteSyncingPage.tsx
@@ -76,7 +76,7 @@ export function RemoteSyncingPage() {
         setIsProcessing(true);
         setStatusMessage(null);
         try {
-            const response = await fetch(syncServerUrl.trim(), { headers: getHeaders() });
+            const response = await fetch(syncServerUrl.trim(), { headers: getHeaders(), cache: 'no-store' });
             if (!response.ok) {
                 throw new Error(`Failed to fetch data: ${response.status} ${response.statusText}`);
             }
@@ -133,6 +133,7 @@ export function RemoteSyncingPage() {
                     'Content-Type': 'application/octet-stream',
                 },
                 body: encryptedBlob,
+                cache: 'no-store'
             });
 
             if (!response.ok) {

--- a/src/services/remoteSyncService.ts
+++ b/src/services/remoteSyncService.ts
@@ -197,7 +197,7 @@ export const remoteSyncService = {
                 customHeaders['x-chaser-token'] = syncHeaderKey;
             }
 
-            const versionResponse = await fetch(`${syncUrl}/version`, { headers: customHeaders });
+            const versionResponse = await fetch(`${syncUrl}/version`, { headers: customHeaders, cache: 'no-store' });
             if (versionResponse.ok) {
                 const versionData = await versionResponse.json();
                 serverLastUpdated = versionData.lastUpdated || 0;
@@ -213,7 +213,7 @@ export const remoteSyncService = {
 
             // 2. Pull & Merge (If Needed)
             if (serverLastUpdated > localLastSynced) {
-                const pullResponse = await fetch(syncUrl, { headers: customHeaders });
+                const pullResponse = await fetch(syncUrl, { headers: customHeaders, cache: 'no-store' });
                 if (pullResponse.ok) {
                     const buffer = await pullResponse.arrayBuffer();
                     if (buffer.byteLength > 0) {
@@ -244,6 +244,7 @@ export const remoteSyncService = {
                         'Content-Type': 'application/octet-stream',
                     },
                     body: encryptedBlob,
+                    cache: 'no-store'
                 });
 
                 if (!pushResponse.ok) {


### PR DESCRIPTION
Adds `cache: 'no-store'` to the fetch configuration objects inside `src/pages/RemoteSyncingPage.tsx` and `src/services/remoteSyncService.ts`. This correctly fulfills the issue requirement ensuring remote syncing fetches fresh payloads and avoids stale blobs returned from browser caching mechanisms.

---
*PR created automatically by Jules for task [12315825670316528516](https://jules.google.com/task/12315825670316528516) started by @John-Bell*