### PR TITLE
feat: make tax band visualizer dynamic and highlight higher rates

### DIFF
--- a/src/components/income/TaxBandVisualizer.tsx
+++ b/src/components/income/TaxBandVisualizer.tsx
@@ -1,27 +1,80 @@
-export function TaxBandVisualizer() {
+import type { TaxCalculationResult } from '@/models/TaxCalculationResult';
+
+interface TaxBandVisualizerProps {
+    totalIncome: number;
+    taxResult: TaxCalculationResult | null;
+}
+
+export function TaxBandVisualizer({ totalIncome, taxResult }: TaxBandVisualizerProps) {
+    const pa = taxResult?.personalAllowance || 12570;
+    // brbExtended is the width of the basic rate band (e.g. 37700)
+    const brbWidth = taxResult?.brbExtended || 37700;
+    const brThreshold = pa + brbWidth; // e.g. 50270
+
+    // Scale primarily to basic rate threshold + a bit extra, unless higher rate is significant.
+    const maxScale = Math.max(brThreshold * 1.05, totalIncome * 1.05);
+
+    const paUsed = Math.min(totalIncome, pa);
+    const paWidth = (paUsed / maxScale) * 100;
+
+    const basicInc = Math.max(0, Math.min(totalIncome - pa, brbWidth));
+    const basicWidth = (basicInc / maxScale) * 100;
+
+    const higherInc = Math.max(0, totalIncome - brThreshold);
+    const higherWidth = (higherInc / maxScale) * 100;
+
+    const formatCurr = (v: number) => `£${v.toLocaleString('en-GB', { maximumFractionDigits: 0 })}`;
+
+    let currentBand = 'Within PA';
+    let bandRate = '0%';
+    let psaTotal = 1000;
+
+    if (totalIncome <= pa) {
+        currentBand = 'Personal Allowance';
+        bandRate = '0%';
+        psaTotal = 1000;
+    } else if (totalIncome <= brThreshold) {
+        currentBand = 'Basic Rate';
+        bandRate = '20%';
+        psaTotal = 1000;
+    } else if (totalIncome <= 125140) {
+        currentBand = 'Higher Rate';
+        bandRate = '40%';
+        psaTotal = 500;
+    } else {
+        currentBand = 'Additional Rate';
+        bandRate = '45%';
+        psaTotal = 0;
+    }
+
+    const savingsIncome = taxResult?.incomeBreakdown?.savingsIncome || 0;
+    const psaRemaining = Math.max(0, psaTotal - savingsIncome);
+
     return (
         <div className="bg-slate-200 dark:bg-[#1c2723] rounded-xl p-5 shadow-sm border border-slate-300 dark:border-[#2f3e37]">
             <div className="flex justify-between items-end mb-4">
                 <div>
                     <p className="text-xs font-semibold uppercase tracking-wider text-slate-500 dark:text-[#9db9b0]">Current Tax Band</p>
                     <h3 className="text-2xl font-bold text-slate-900 dark:text-white mt-1">
-                        Basic Rate <span className="text-primary text-lg font-normal">(20%)</span>
+                        {currentBand} <span className={currentBand === 'Higher Rate' || currentBand === 'Additional Rate' ? "text-red-500 text-lg font-normal" : "text-primary text-lg font-normal"}>({bandRate})</span>
                     </h3>
                 </div>
                 <div className="text-right">
                     <p className="text-xs font-medium text-slate-500 dark:text-[#9db9b0]">PSA Remaining</p>
-                    <p className="text-lg font-bold text-primary">£1,000</p>
+                    <p className="text-lg font-bold text-primary">{formatCurr(psaRemaining)}</p>
                 </div>
             </div>
+
             <div className="relative w-full h-8 bg-slate-300 dark:bg-[#111816] rounded-full overflow-hidden flex">
-                <div className="h-full bg-primary/40 flex items-center justify-center text-[10px] font-bold text-primary-900" style={{ width: '25%' }}>£12,570</div>
-                <div className="h-full bg-primary flex items-center justify-center text-[10px] font-bold text-[#10221c]" style={{ width: '45%' }}>£32,000</div>
-                <div className="h-full flex-1"></div>
+                {paWidth > 0 && <div className="h-full bg-primary/40 flex items-center justify-center text-[10px] font-bold text-primary-900" style={{ width: `${paWidth}%` }}>{formatCurr(paUsed)}</div>}
+                {basicWidth > 0 && <div className="h-full bg-primary flex items-center justify-center text-[10px] font-bold text-[#10221c]" style={{ width: `${basicWidth}%` }}>{formatCurr(basicInc)}</div>}
+                {higherWidth > 0 && <div className="h-full bg-red-500 flex items-center justify-center text-[10px] font-bold text-white" style={{ width: `${higherWidth}%` }}>{formatCurr(higherInc)}</div>}
             </div>
+
             <div className="flex justify-between mt-2 text-xs text-slate-500 dark:text-[#9db9b0]">
                 <span>£0</span>
-                <span className="font-medium text-slate-900 dark:text-white">Total: £44,570</span>
-                <span>£50,270</span>
+                <span className="font-medium text-slate-900 dark:text-white">Total: {formatCurr(totalIncome)}</span>
+                <span>{formatCurr(maxScale)}</span>
             </div>
         </div>
     );

--- a/src/pages/IncomeEditPage.test.tsx
+++ b/src/pages/IncomeEditPage.test.tsx
@@ -9,6 +9,15 @@ vi.mock('@/store/useStore', () => ({
     useStore: vi.fn(),
 }));
 
+vi.mock('@/hooks/useTaxCalculations', () => ({
+    useTaxCalculations: vi.fn(() => ({
+        p1TaxResult: { personalAllowance: 12570, brbExtended: 50270, incomeBreakdown: { savingsIncome: 0 } },
+        p2TaxResult: { personalAllowance: 12570, brbExtended: 50270, incomeBreakdown: { savingsIncome: 0 } },
+        p1TotalIncome: 50000,
+        p2TotalIncome: 50000,
+    })),
+}));
+
 describe('IncomeEditPage', () => {
     it('renders tabs and allows switching between partners', () => {
         // Mock store return value

--- a/src/pages/IncomeEditPage.tsx
+++ b/src/pages/IncomeEditPage.tsx
@@ -12,6 +12,7 @@ import { IncomeEntryForm } from '../components/income/IncomeEntryForm';
 import { useStore } from '@/store/useStore';
 import { MainHeaderActions } from '../components/layout/MainHeaderActions';
 import { useIncomeForm } from '@/hooks/useIncomeForm';
+import { useTaxCalculations } from '@/hooks/useTaxCalculations';
 
 export function IncomeEditPage() {
     const navigate = useNavigate();
@@ -21,6 +22,14 @@ export function IncomeEditPage() {
 
     const [activeTabKey, setActiveTabKey] = useState<'partner1' | 'partner2'>('partner1');
     const ownerId = activeTabKey === 'partner1' ? 'person1' : 'person2';
+
+    const {
+        p1TaxResult, p2TaxResult,
+        p1TotalIncome, p2TotalIncome
+    } = useTaxCalculations();
+
+    const activeTaxResult = activeTabKey === 'partner1' ? p1TaxResult : p2TaxResult;
+    const activeTotalIncome = activeTabKey === 'partner1' ? p1TotalIncome : p2TotalIncome;
 
     const {
         incomes,
@@ -76,7 +85,7 @@ export function IncomeEditPage() {
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-2 gap-8 px-4 py-6 md:pb-12 max-w-7xl mx-auto">
                 {/* Left Column: Flow & Lists */}
                 <div className="space-y-8">
-                    <TaxBandVisualizer />
+                    <TaxBandVisualizer totalIncome={activeTotalIncome} taxResult={activeTaxResult} />
 
                     {/* Pensions */}
                     <section>


### PR DESCRIPTION
This PR updates the `TaxBandVisualizer` on the `IncomeEditPage` to feed from dynamic tax data instead of hardcoded values.

Key changes:
- `TaxBandVisualizer` now accepts `totalIncome` and `taxResult` as props.
- `IncomeEditPage` uses the `useTaxCalculations` hook to pass the correct active tab's tax result.
- Red highlighting is applied automatically to any income crossing into the Higher Rate or Additional Rate bands.
- Accurately computes remaining Personal Savings Allowance (PSA).
- Fixes domain logic in the visual bar where `brbExtended` correctly represents the width of the basic rate band, correctly plotting the absolute Basic Rate threshold.

---
*PR created automatically by Jules for task [17890019225120372780](https://jules.google.com/task/17890019225120372780) started by @John-Bell*