### PR TITLE
feat: isolate simulator calculations and add property breakdown

### DIFF
--- a/src/hooks/useSimulatorCalculations.ts
+++ b/src/hooks/useSimulatorCalculations.ts
@@ -1,0 +1,229 @@
+import { useMemo } from 'react';
+import { useLiveQuery } from 'dexie-react-hooks';
+import { db } from '@/lib/db';
+import { useStore } from '@/store/useStore';
+import { useTaxService } from '@/hooks/useTaxService';
+import type { TaxCalculationInput } from '@/models/TaxCalculationInput';
+import type { TaxCalculationResult } from '@/models/TaxCalculationResult';
+import { calculateProjectedAnnualInterest } from '@/utils/interestCalculations';
+import { getTaxYearDates } from '@/constants/taxConstants';
+import { calculatePropertyIncomeForTaxYear, calculatePropertyExpensesForTaxYear } from '@/utils/propertyCalculations';
+
+export interface PropertyBreakdown {
+    propertyId: string;
+    propertyName: string;
+    p1Income: number;
+    p2Income: number;
+    p1Expense: number;
+    p2Expense: number;
+}
+
+export interface UseSimulatorCalculationsResult {
+    p1Incomes: { employment: number; pension: number; propertyIncome: number; propertyExpense: number; dividends: number; interest: number };
+    p2Incomes: { employment: number; pension: number; propertyIncome: number; propertyExpense: number; dividends: number; interest: number };
+    p1TaxResult: TaxCalculationResult | null;
+    p2TaxResult: TaxCalculationResult | null;
+    p1TotalIncome: number;
+    p2TotalIncome: number;
+    combinedNet: number;
+    combinedTotalTax: number;
+    combinedEffectiveRate: number;
+    propertyBreakdowns: PropertyBreakdown[];
+    p1MovableInterest: number;
+    p2MovableInterest: number;
+    totalMovableInterest: number;
+    isReady: boolean;
+}
+
+export function useSimulatorCalculations(): UseSimulatorCalculationsResult {
+    const { taxYear } = useStore();
+    const taxService = useTaxService();
+
+    const dbAccounts = useLiveQuery(() => db.accounts.toArray());
+    const dbIncomes = useLiveQuery(() => db.incomes.toArray());
+    const dbInterestAccruals = useLiveQuery(() => db.interestAccruals.toArray());
+    const dbProperties = useLiveQuery(() => db.properties.toArray());
+    const dbPropertyIncomes = useLiveQuery(() => db.propertyIncomes.toArray());
+    const dbPropertyExpenses = useLiveQuery(() => db.propertyExpenses.toArray());
+    const dbPropertyOwnerships = useLiveQuery(() => db.propertyOwnership.toArray());
+
+    return useMemo(() => {
+        const allAccruals = dbInterestAccruals || [];
+        const p1Incomes = { employment: 0, pension: 0, propertyIncome: 0, propertyExpense: 0, dividends: 0, interest: 0 };
+        const p2Incomes = { employment: 0, pension: 0, propertyIncome: 0, propertyExpense: 0, dividends: 0, interest: 0 };
+
+        let p1MovableInterest = 0;
+        let p2MovableInterest = 0;
+
+        if (dbIncomes) {
+            dbIncomes.forEach(inc => {
+                const amount = inc.frequency === 'monthly' ? inc.amount * 12 : inc.amount;
+                const target = inc.ownerId === 'person1' ? p1Incomes : p2Incomes;
+
+                if (inc.type === 'employment') target.employment += amount;
+                else if (inc.type === 'pension') target.pension += amount;
+                else if (inc.type === 'dividends') target.dividends += amount;
+            });
+        }
+
+        const { startTs, endTs } = getTaxYearDates(taxYear || undefined);
+
+        const propertyBreakdowns: PropertyBreakdown[] = [];
+
+        if (dbProperties && dbPropertyIncomes && dbPropertyOwnerships && dbPropertyExpenses) {
+            dbProperties.forEach(property => {
+                const { p1Rental, p2Rental } = calculatePropertyIncomeForTaxYear(
+                    dbPropertyIncomes.filter(i => i.propertyId === property.id),
+                    dbPropertyOwnerships.filter(o => o.propertyId === property.id),
+                    startTs,
+                    endTs
+                );
+
+                const { p1Expenses, p2Expenses } = calculatePropertyExpensesForTaxYear(
+                    dbPropertyExpenses.filter(e => e.propertyId === property.id),
+                    dbPropertyOwnerships.filter(o => o.propertyId === property.id),
+                    startTs,
+                    endTs
+                );
+
+                if (p1Rental > 0 || p2Rental > 0 || p1Expenses > 0 || p2Expenses > 0) {
+                    propertyBreakdowns.push({
+                        propertyId: property.id,
+                        propertyName: property.name,
+                        p1Income: p1Rental,
+                        p2Income: p2Rental,
+                        p1Expense: p1Expenses,
+                        p2Expense: p2Expenses
+                    });
+                }
+
+                p1Incomes.propertyIncome += p1Rental;
+                p2Incomes.propertyIncome += p2Rental;
+                p1Incomes.propertyExpense += p1Expenses;
+                p2Incomes.propertyExpense += p2Expenses;
+            });
+        } else if (dbPropertyIncomes && dbPropertyOwnerships && dbPropertyExpenses) {
+            // Fallback if no dbProperties loaded yet but we have the raw incomes/expenses
+            const { p1Rental, p2Rental } = calculatePropertyIncomeForTaxYear(
+                dbPropertyIncomes,
+                dbPropertyOwnerships,
+                startTs,
+                endTs
+            );
+            p1Incomes.propertyIncome += p1Rental;
+            p2Incomes.propertyIncome += p2Rental;
+
+            const { p1Expenses, p2Expenses } = calculatePropertyExpensesForTaxYear(
+                dbPropertyExpenses,
+                dbPropertyOwnerships,
+                startTs,
+                endTs
+            );
+            p1Incomes.propertyExpense += p1Expenses;
+            p2Incomes.propertyExpense += p2Expenses;
+        }
+
+        if (dbAccounts) {
+            dbAccounts.forEach(acc => {
+                const taxFreeCategories = ['Cash ISA', 'Shares ISA', 'Premium Bonds'];
+                if (acc.category && taxFreeCategories.includes(acc.category as string)) {
+                    return;
+                }
+
+                const accountAccruals = allAccruals.filter(a => a.accountId === acc.id);
+                const amount = calculateProjectedAnnualInterest(acc, accountAccruals, startTs, endTs);
+
+                if (acc.ownerId === 'person1') p1Incomes.interest += amount;
+                else if (acc.ownerId === 'person2') p2Incomes.interest += amount;
+                else if (acc.ownerId === 'joint') {
+                    p1Incomes.interest += amount / 2;
+                    p2Incomes.interest += amount / 2;
+                }
+
+                // Check for movable interest
+                const movableTaxFreeCategories = ['Cash ISA', 'Shares ISA', 'Premium Bonds', 'DC Pension'];
+                if (acc.category && movableTaxFreeCategories.includes(acc.category as string)) {
+                    return;
+                }
+
+                const frequency = acc.interestPayoutFrequency || 'monthly';
+                const payoutTs = acc.interestPayoutDate;
+
+                if (frequency === 'annually' || frequency === 'at_maturity' || payoutTs) {
+                    return;
+                }
+
+                if (acc.ownerId === 'person1') p1MovableInterest += amount;
+                else if (acc.ownerId === 'person2') p2MovableInterest += amount;
+                else if (acc.ownerId === 'joint') {
+                    p1MovableInterest += amount / 2;
+                    p2MovableInterest += amount / 2;
+                }
+            });
+        }
+
+        const p1NetPropertyIncome = Math.max(0, p1Incomes.propertyIncome - p1Incomes.propertyExpense);
+        const p2NetPropertyIncome = Math.max(0, p2Incomes.propertyIncome - p2Incomes.propertyExpense);
+
+        const p1Input: TaxCalculationInput = {
+            salary: p1Incomes.employment,
+            rentalIncome: p1NetPropertyIncome,
+            pensionIncome: p1Incomes.pension,
+            untaxedInterest: p1Incomes.interest,
+            dividends: p1Incomes.dividends,
+            directPensionContrib: 0,
+            otherIncome: 0
+        };
+
+        const p2Input: TaxCalculationInput = {
+            salary: p2Incomes.employment,
+            rentalIncome: p2NetPropertyIncome,
+            pensionIncome: p2Incomes.pension,
+            untaxedInterest: p2Incomes.interest,
+            dividends: p2Incomes.dividends,
+            directPensionContrib: 0,
+            otherIncome: 0
+        };
+
+        let p1TaxResult: TaxCalculationResult | null = null;
+        let p2TaxResult: TaxCalculationResult | null = null;
+
+        if (taxService) {
+            p1TaxResult = taxService.calculateTax(p1Input, taxYear || undefined);
+            p2TaxResult = taxService.calculateTax(p2Input, taxYear || undefined);
+        }
+
+        const p1TotalIncome = p1Incomes.employment + p1Incomes.pension + p1NetPropertyIncome + p1Incomes.dividends + p1Incomes.interest;
+        const p2TotalIncome = p2Incomes.employment + p2Incomes.pension + p2NetPropertyIncome + p2Incomes.dividends + p2Incomes.interest;
+
+        const p1Net = p1TotalIncome - (p1TaxResult?.totalTax || 0);
+        const p2Net = p2TotalIncome - (p2TaxResult?.totalTax || 0);
+
+        const combinedNet = p1Net + p2Net;
+
+        const combinedTotalTax = (p1TaxResult?.totalTax || 0) + (p2TaxResult?.totalTax || 0);
+        const combinedTotalIncome = p1TotalIncome + p2TotalIncome;
+
+        const combinedEffectiveRate = combinedTotalIncome > 0 ? (combinedTotalTax / combinedTotalIncome) * 100 : 0;
+
+        const totalMovableInterest = p1MovableInterest + p2MovableInterest;
+
+        return {
+            p1Incomes,
+            p2Incomes,
+            p1TaxResult,
+            p2TaxResult,
+            p1TotalIncome,
+            p2TotalIncome,
+            combinedNet,
+            combinedTotalTax,
+            combinedEffectiveRate,
+            propertyBreakdowns,
+            p1MovableInterest,
+            p2MovableInterest,
+            totalMovableInterest,
+            isReady: !!dbAccounts && !!dbIncomes && !!taxService && !!dbProperties && !!dbPropertyIncomes && !!dbPropertyExpenses && !!dbPropertyOwnerships
+        };
+
+    }, [dbAccounts, dbIncomes, dbInterestAccruals, dbProperties, dbPropertyIncomes, dbPropertyExpenses, dbPropertyOwnerships, taxService, taxYear]);
+}

--- a/src/pages/SimulatorPage.tsx
+++ b/src/pages/SimulatorPage.tsx
@@ -1,63 +1,25 @@
+import React from 'react';
 import { AppLayout } from '../components/layout/AppLayout';
 import { Header } from '../components/layout/Header';
 import { MainHeaderActions } from '../components/layout/MainHeaderActions';
 import { Icon } from '../components/ui/Icon';
 import { useStore } from '@/store/useStore';
-import { useTaxCalculations } from '@/hooks/useTaxCalculations';
-import { useLiveQuery } from 'dexie-react-hooks';
-import { db } from '@/lib/db';
-import { calculateProjectedAnnualInterest } from '@/utils/interestCalculations';
-import { getTaxYearDates } from '@/constants/taxConstants';
+import { useSimulatorCalculations } from '@/hooks/useSimulatorCalculations';
 
 export function SimulatorPage() {
-    const { profile, taxYear } = useStore();
+    const { profile } = useStore();
     const p1Name = profile?.partner1Name || 'Person 1';
     const p2Name = profile?.partner2Name || 'Person 2';
-
-    const dbAccounts = useLiveQuery(() => db.accounts.toArray());
-    const dbInterestAccruals = useLiveQuery(() => db.interestAccruals.toArray());
-
-    const { startTs, endTs } = getTaxYearDates(taxYear || undefined);
-
-    let p1MovableInterest = 0;
-    let p2MovableInterest = 0;
-
-    if (dbAccounts) {
-        const allAccruals = dbInterestAccruals || [];
-        dbAccounts.forEach(acc => {
-            // 1. Exclude tax-free accounts
-            const taxFreeCategories = ['Cash ISA', 'Shares ISA', 'Premium Bonds', 'DC Pension'];
-            if (acc.category && taxFreeCategories.includes(acc.category as string)) {
-                return;
-            }
-
-            // 2. Exclude accounts with annual or at_maturity payouts, or specific payout dates
-            const frequency = acc.interestPayoutFrequency || 'monthly';
-            const payoutTs = acc.interestPayoutDate;
-
-            if (frequency === 'annually' || frequency === 'at_maturity' || payoutTs) {
-                return;
-            }
-
-            const accountAccruals = allAccruals.filter(a => a.accountId === acc.id);
-            const amount = calculateProjectedAnnualInterest(acc, accountAccruals, startTs, endTs);
-
-            if (acc.ownerId === 'person1') p1MovableInterest += amount;
-            else if (acc.ownerId === 'person2') p2MovableInterest += amount;
-            else if (acc.ownerId === 'joint') {
-                p1MovableInterest += amount / 2;
-                p2MovableInterest += amount / 2;
-            }
-        });
-    }
-
-    const totalMovableInterest = p1MovableInterest + p2MovableInterest;
 
     const {
         p1Incomes, p2Incomes,
         p1TotalIncome: p1Total, p2TotalIncome: p2Total,
-        combinedNet
-    } = useTaxCalculations();
+        combinedNet,
+        propertyBreakdowns,
+        p1MovableInterest,
+        p2MovableInterest,
+        totalMovableInterest
+    } = useSimulatorCalculations();
 
     const formatCurr = (v: number) => `£${v.toLocaleString('en-GB', { maximumFractionDigits: 0 })}`;
 
@@ -101,16 +63,35 @@ export function SimulatorPage() {
                                     <td className="px-4 py-4 text-right">{formatCurr(p1Incomes.pension)}</td>
                                     <td className="px-4 py-4 text-right">{formatCurr(p2Incomes.pension)}</td>
                                 </tr>
-                                <tr>
-                                    <td className="px-4 py-4 font-medium">Rental Income</td>
-                                    <td className="px-4 py-4 text-right text-primary font-bold">{formatCurr(p1Incomes.propertyIncome)}</td>
-                                    <td className="px-4 py-4 text-right text-primary font-bold">{formatCurr(p2Incomes.propertyIncome)}</td>
-                                </tr>
-                                <tr>
-                                    <td className="px-4 py-4 font-medium">Rental Expenses</td>
-                                    <td className="px-4 py-4 text-right text-red-500 font-bold">{formatCurr(p1Incomes.propertyExpense)}</td>
-                                    <td className="px-4 py-4 text-right text-red-500 font-bold">{formatCurr(p2Incomes.propertyExpense)}</td>
-                                </tr>
+                                {propertyBreakdowns.length > 0 ? (
+                                    propertyBreakdowns.map((prop) => (
+                                        <React.Fragment key={prop.propertyId}>
+                                            <tr>
+                                                <td className="px-4 py-4 font-medium">{prop.propertyName} Income</td>
+                                                <td className="px-4 py-4 text-right text-primary font-bold">{formatCurr(prop.p1Income)}</td>
+                                                <td className="px-4 py-4 text-right text-primary font-bold">{formatCurr(prop.p2Income)}</td>
+                                            </tr>
+                                            <tr>
+                                                <td className="px-4 py-4 font-medium">{prop.propertyName} Expenses</td>
+                                                <td className="px-4 py-4 text-right text-red-500 font-bold">{formatCurr(prop.p1Expense)}</td>
+                                                <td className="px-4 py-4 text-right text-red-500 font-bold">{formatCurr(prop.p2Expense)}</td>
+                                            </tr>
+                                        </React.Fragment>
+                                    ))
+                                ) : (
+                                    <>
+                                        <tr>
+                                            <td className="px-4 py-4 font-medium">Rental Income</td>
+                                            <td className="px-4 py-4 text-right text-primary font-bold">{formatCurr(p1Incomes.propertyIncome)}</td>
+                                            <td className="px-4 py-4 text-right text-primary font-bold">{formatCurr(p2Incomes.propertyIncome)}</td>
+                                        </tr>
+                                        <tr>
+                                            <td className="px-4 py-4 font-medium">Rental Expenses</td>
+                                            <td className="px-4 py-4 text-right text-red-500 font-bold">{formatCurr(p1Incomes.propertyExpense)}</td>
+                                            <td className="px-4 py-4 text-right text-red-500 font-bold">{formatCurr(p2Incomes.propertyExpense)}</td>
+                                        </tr>
+                                    </>
+                                )}
                                 <tr>
                                     <td className="px-4 py-4 font-medium">Dividends</td>
                                     <td className="px-4 py-4 text-right">{formatCurr(p1Incomes.dividends)}</td>


### PR DESCRIPTION
This PR addresses the need for a dedicated service/hook for the Simulator page to perform complex optimizations related to movable interest and property ownership, without breaking or mutating the existing baseline hooks.

### Changes Made:
- **`useSimulatorCalculations` Hook:** Created a new custom React hook that mirrors the base `useTaxCalculations` hook but introduces specific simulator metrics:
  - `p1MovableInterest`, `p2MovableInterest`, `totalMovableInterest`
  - `propertyBreakdowns`: An array that splits and aggregates properties based on their ownership, enabling precise display per property.
- **`SimulatorPage` Component:** 
  - Subbed out `useTaxCalculations` for the new `useSimulatorCalculations`.
  - Removed all manually calculated movable interest loops since it's now handled smoothly in the backend hook.
  - Refactored the UI "Detailed Breakdown" table to dynamically map over the `propertyBreakdowns` array, displaying `[Property Name] Income` and `[Property Name] Expenses`.
  - Added a clean fallback mechanism to display standard "Rental Income" and "Rental Expenses" when no properties exist.
- Verified functionality successfully visually with Playwright E2E and passing unit tests.

---
*PR created automatically by Jules for task [152244810641868307](https://jules.google.com/task/152244810641868307) started by @John-Bell*