### PR TITLE
Add tax row to Simulator Page

### DIFF
--- a/src/pages/SimulatorPage.tsx
+++ b/src/pages/SimulatorPage.tsx
@@ -15,6 +15,7 @@ export function SimulatorPage() {
     const {
         p1Incomes, p2Incomes,
         p1TotalIncome: p1Total, p2TotalIncome: p2Total,
+        p1TaxResult, p2TaxResult,
         combinedNet,
         propertyBreakdowns,
         p1MovableInterest,
@@ -109,6 +110,11 @@ export function SimulatorPage() {
                                     <td className="px-4 py-4">Total Gross</td>
                                     <td className="px-4 py-4 text-right">{formatCurr(p1Total)}</td>
                                     <td className="px-4 py-4 text-right">{formatCurr(p2Total)}</td>
+                                </tr>
+                                <tr className="border-t border-slate-200 dark:border-primary/10">
+                                    <td className="px-4 py-4 font-medium text-slate-500">Tax</td>
+                                    <td className="px-4 py-4 text-right text-red-500 font-bold">{formatCurr(p1TaxResult?.totalTax || 0)}</td>
+                                    <td className="px-4 py-4 text-right text-red-500 font-bold">{formatCurr(p2TaxResult?.totalTax || 0)}</td>
                                 </tr>
                                 <tr className="border-t border-slate-200 dark:border-primary/10">
                                     <td className="px-4 py-4 text-primary">Combined Net</td>


### PR DESCRIPTION
Extracted the tax results inside the simulator page and included them correctly within the total breakdown view to see tax reductions below gross amounts.

---
*PR created automatically by Jules for task [9991509473027422808](https://jules.google.com/task/9991509473027422808) started by @John-Bell*