### PR TITLE
Add property income split sliders to simulator

### DIFF
--- a/src/hooks/useSimulatorCalculations.ts
+++ b/src/hooks/useSimulatorCalculations.ts
@@ -35,7 +35,7 @@ export interface UseSimulatorCalculationsResult {
     isReady: boolean;
 }
 
-export function useSimulatorCalculations(movableInterestP1Percent?: number): UseSimulatorCalculationsResult {
+export function useSimulatorCalculations(movableInterestP1Percent?: number, propertySplits?: Record<string, number>): UseSimulatorCalculationsResult {
     const { taxYear } = useStore();
     const taxService = useTaxService();
 
@@ -86,21 +86,39 @@ export function useSimulatorCalculations(movableInterestP1Percent?: number): Use
                     endTs
                 );
 
-                if (p1Rental > 0 || p2Rental > 0 || p1Expenses > 0 || p2Expenses > 0) {
+                let finalP1Rental = p1Rental;
+                let finalP2Rental = p2Rental;
+                let finalP1Expenses = p1Expenses;
+                let finalP2Expenses = p2Expenses;
+
+                if (propertySplits && propertySplits[property.id] !== undefined) {
+                    const splitP1 = propertySplits[property.id];
+                    const splitP2 = 100 - splitP1;
+
+                    const totalRental = p1Rental + p2Rental;
+                    const totalExpense = p1Expenses + p2Expenses;
+
+                    finalP1Rental = totalRental * (splitP1 / 100);
+                    finalP2Rental = totalRental * (splitP2 / 100);
+                    finalP1Expenses = totalExpense * (splitP1 / 100);
+                    finalP2Expenses = totalExpense * (splitP2 / 100);
+                }
+
+                if (finalP1Rental > 0 || finalP2Rental > 0 || finalP1Expenses > 0 || finalP2Expenses > 0) {
                     propertyBreakdowns.push({
                         propertyId: property.id,
                         propertyName: property.name,
-                        p1Income: p1Rental,
-                        p2Income: p2Rental,
-                        p1Expense: p1Expenses,
-                        p2Expense: p2Expenses
+                        p1Income: finalP1Rental,
+                        p2Income: finalP2Rental,
+                        p1Expense: finalP1Expenses,
+                        p2Expense: finalP2Expenses
                     });
                 }
 
-                p1Incomes.propertyIncome += p1Rental;
-                p2Incomes.propertyIncome += p2Rental;
-                p1Incomes.propertyExpense += p1Expenses;
-                p2Incomes.propertyExpense += p2Expenses;
+                p1Incomes.propertyIncome += finalP1Rental;
+                p2Incomes.propertyIncome += finalP2Rental;
+                p1Incomes.propertyExpense += finalP1Expenses;
+                p2Incomes.propertyExpense += finalP2Expenses;
             });
         } else if (dbPropertyIncomes && dbPropertyOwnerships && dbPropertyExpenses) {
             // Fallback if no dbProperties loaded yet but we have the raw incomes/expenses
@@ -236,5 +254,5 @@ export function useSimulatorCalculations(movableInterestP1Percent?: number): Use
             isReady: !!dbAccounts && !!dbIncomes && !!taxService && !!dbProperties && !!dbPropertyIncomes && !!dbPropertyExpenses && !!dbPropertyOwnerships
         };
 
-    }, [dbAccounts, dbIncomes, dbInterestAccruals, dbProperties, dbPropertyIncomes, dbPropertyExpenses, dbPropertyOwnerships, taxService, taxYear, movableInterestP1Percent]);
+    }, [dbAccounts, dbIncomes, dbInterestAccruals, dbProperties, dbPropertyIncomes, dbPropertyExpenses, dbPropertyOwnerships, taxService, taxYear, movableInterestP1Percent, propertySplits]);
 }

--- a/src/pages/SimulatorPage.tsx
+++ b/src/pages/SimulatorPage.tsx
@@ -9,6 +9,7 @@ import { useSimulatorCalculations } from '@/hooks/useSimulatorCalculations';
 export function SimulatorPage() {
     const { profile } = useStore();
     const [movableInterestP1Percent, setMovableInterestP1Percent] = React.useState<number | undefined>();
+    const [propertySplits, setPropertySplits] = React.useState<Record<string, number>>({});
     const p1Name = profile?.partner1Name || 'Person 1';
     const p2Name = profile?.partner2Name || 'Person 2';
 
@@ -21,7 +22,11 @@ export function SimulatorPage() {
         p1MovableInterest,
         p2MovableInterest,
         totalMovableInterest
-    } = useSimulatorCalculations(movableInterestP1Percent);
+    } = useSimulatorCalculations(movableInterestP1Percent, propertySplits);
+
+    const handlePropertySplitChange = (propertyId: string, value: number) => {
+        setPropertySplits(prev => ({ ...prev, [propertyId]: value }));
+    };
 
     const formatCurr = (v: number) => `£${v.toLocaleString('en-GB', { maximumFractionDigits: 0 })}`;
 
@@ -182,6 +187,47 @@ export function SimulatorPage() {
                             />
                         </div>
                     )}
+
+                    {propertyBreakdowns.length > 0 && propertyBreakdowns.map((prop) => {
+                        const totalPropIncome = prop.p1Income + prop.p2Income;
+                        const currentValue = propertySplits[prop.propertyId] !== undefined
+                            ? propertySplits[prop.propertyId]
+                            : (totalPropIncome > 0 ? (prop.p1Income / totalPropIncome) * 100 : 50);
+
+                        return (
+                            <div key={prop.propertyId} className="bg-slate-50 dark:bg-primary/5 rounded-2xl p-6 space-y-4 mt-4">
+                                <div className="flex items-center justify-between mb-4">
+                                    <div className="space-y-1">
+                                        <h3 className="font-bold text-lg text-slate-900 dark:text-white">{prop.propertyName} Income Split</h3>
+                                        <p className="text-sm text-slate-500 dark:text-primary/60">Split projected {formatCurr(totalPropIncome)}</p>
+                                    </div>
+                                    <div className="w-12 h-12 rounded-full bg-white dark:bg-background-dark flex items-center justify-center text-primary shadow-sm">
+                                        <Icon name="home" className="text-2xl" />
+                                    </div>
+                                </div>
+
+                                <div className="flex justify-between items-end mb-2">
+                                    <div className="space-y-1">
+                                        <div className="text-xs font-bold uppercase tracking-wider text-slate-500 dark:text-primary/60">{p1Name}</div>
+                                        <div className="text-2xl font-bold text-primary">{formatCurr(prop.p1Income)}</div>
+                                    </div>
+                                    <div className="space-y-1 text-right">
+                                        <div className="text-xs font-bold uppercase tracking-wider text-slate-500 dark:text-primary/60">{p2Name}</div>
+                                        <div className="text-2xl font-bold text-slate-700 dark:text-slate-300">{formatCurr(prop.p2Income)}</div>
+                                    </div>
+                                </div>
+
+                                <input
+                                    type="range"
+                                    min="0"
+                                    max="100"
+                                    value={currentValue}
+                                    onChange={(e) => handlePropertySplitChange(prop.propertyId, Number(e.target.value))}
+                                    className="w-full appearance-none bg-transparent [&::-webkit-slider-runnable-track]:rounded-full [&::-webkit-slider-runnable-track]:bg-slate-200 dark:[&::-webkit-slider-runnable-track]:bg-primary/20 [&::-webkit-slider-runnable-track]:h-2 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:h-6 [&::-webkit-slider-thumb]:w-6 [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-white [&::-webkit-slider-thumb]:border-4 [&::-webkit-slider-thumb]:border-primary [&::-webkit-slider-thumb]:-mt-2"
+                                />
+                            </div>
+                        );
+                    })}
                 </section>
             </div>
         </AppLayout>


### PR DESCRIPTION
This PR introduces the ability to manually override property income and expense attribution splits directly within the Simulator Page. By adding a slider per property, users can easily visualize how changing ownership structures (e.g. from Joint to strictly Person 1) will impact their projected total gross, net, and tax burdens without permanently altering their Dexie database records.

---
*PR created automatically by Jules for task [1666861385631931124](https://jules.google.com/task/1666861385631931124) started by @John-Bell*