### PR TITLE
Add Combined Tax row to Simulator page breakdown

### DIFF
--- a/src/pages/SimulatorPage.tsx
+++ b/src/pages/SimulatorPage.tsx
@@ -125,6 +125,10 @@ export function SimulatorPage() {
                                     <td className="px-4 py-4 text-primary">Combined Net</td>
                                     <td colSpan={2} className="px-4 py-4 text-right text-primary text-lg">{formatCurr(combinedNet)}</td>
                                 </tr>
+                                <tr className="border-t border-slate-200 dark:border-primary/10">
+                                    <td className="px-4 py-4 text-red-500">Combined Tax</td>
+                                    <td colSpan={2} className="px-4 py-4 text-right text-red-500 font-bold text-lg">{formatCurr((p1TaxResult?.totalTax || 0) + (p2TaxResult?.totalTax || 0))}</td>
+                                </tr>
                             </tfoot>
                         </table>
                     </div>


### PR DESCRIPTION
Added a "Combined Tax" row directly underneath the "Combined Net" row on the Simulator page (`src/pages/SimulatorPage.tsx`). The new row calculates the sum of both partners' tax results `(p1TaxResult?.totalTax || 0) + (p2TaxResult?.totalTax || 0)` and styles the output with `text-red-500 font-bold` to denote a negative financial impact, matching existing conventions for taxes and expenses.

---
*PR created automatically by Jules for task [4833292598477736220](https://jules.google.com/task/4833292598477736220) started by @John-Bell*