### PR TITLE
feat: display property allowance applied note on income and simulator pages

### DIFF
--- a/src/pages/IncomePage.tsx
+++ b/src/pages/IncomePage.tsx
@@ -105,6 +105,13 @@ export function IncomePage() {
                                     <td className="px-4 py-4 text-right text-red-500 font-bold">{formatCurr(p1Incomes.propertyExpense)}</td>
                                     <td className="px-4 py-4 text-right text-red-500 font-bold">{formatCurr(p2Incomes.propertyExpense)}</td>
                                 </tr>
+                                {(p1TaxResult?.propertyAllowanceApplied || p2TaxResult?.propertyAllowanceApplied) && (
+                                    <tr className="bg-slate-50/50 dark:bg-primary/5 text-xs text-slate-500 dark:text-primary/60 italic">
+                                        <td className="px-4 py-2"></td>
+                                        <td className="px-4 py-2 text-right">{p1TaxResult?.propertyAllowanceApplied ? 'Property Allowance Applied' : ''}</td>
+                                        <td className="px-4 py-2 text-right">{p2TaxResult?.propertyAllowanceApplied ? 'Property Allowance Applied' : ''}</td>
+                                    </tr>
+                                )}
                                 <tr>
                                     <td className="px-4 py-4 font-medium">Dividends</td>
                                     <td className="px-4 py-4 text-right">{formatCurr(p1Incomes.dividends)}</td>

--- a/src/pages/SimulatorPage.tsx
+++ b/src/pages/SimulatorPage.tsx
@@ -99,6 +99,13 @@ export function SimulatorPage() {
                                         </tr>
                                     </>
                                 )}
+                                {(p1TaxResult?.propertyAllowanceApplied || p2TaxResult?.propertyAllowanceApplied) && (
+                                    <tr className="bg-slate-50/50 dark:bg-primary/5 text-xs text-slate-500 dark:text-primary/60 italic">
+                                        <td className="px-4 py-2"></td>
+                                        <td className="px-4 py-2 text-right">{p1TaxResult?.propertyAllowanceApplied ? 'Property Allowance Applied' : ''}</td>
+                                        <td className="px-4 py-2 text-right">{p2TaxResult?.propertyAllowanceApplied ? 'Property Allowance Applied' : ''}</td>
+                                    </tr>
+                                )}
                                 <tr>
                                     <td className="px-4 py-4 font-medium">Dividends</td>
                                     <td className="px-4 py-4 text-right">{formatCurr(p1Incomes.dividends)}</td>


### PR DESCRIPTION
This PR implements the requested feature to display a "Property Allowance Applied" note on the `IncomePage` and `SimulationPage` (now `SimulatorPage`) when `propertyAllowanceApplied` is true in the respective person's tax calculation result.

**Changes:**
- `src/pages/IncomePage.tsx`: Added a conditional row beneath the `Rental Expenses` row in the Detailed Breakdown table.
- `src/pages/SimulatorPage.tsx`: Added a conditional row immediately preceding the `Dividends` row, which sits beneath the property/rental section.
- The note correctly applies per-person, rendering dynamically under the corresponding column.

**Verification:**
- Ran Vite build and all tests (`npm run test` and `npx playwright test`).
- Visually validated changes against the frontend by spinning up a local dev server and capturing screenshots via an automated Playwright script simulating £500 property income (triggering the allowance).

---
*PR created automatically by Jules for task [17610494200074938887](https://jules.google.com/task/17610494200074938887) started by @John-Bell*