### PR TITLE
Remove month-end balance from manual interest entries

### DIFF
--- a/src/components/accounts/InterestLedger.tsx
+++ b/src/components/accounts/InterestLedger.tsx
@@ -6,7 +6,6 @@ import { DateInput } from '@/components/ui/DateInput';
 
 interface InterestLedgerProps {
     accountId: string;
-    currentBalance: number;
 }
 
 export function InterestLedger({ accountId }: InterestLedgerProps) {
@@ -15,11 +14,10 @@ export function InterestLedger({ accountId }: InterestLedgerProps) {
     // For "MONTH & YEAR" we can use a string input of "YYYY-MM"
     const [editingId, setEditingId] = useState<string | null>(null);
     const [monthYear, setMonthYear] = useState('');
-    const [balance, setBalance] = useState('');
     const [interest, setInterest] = useState('');
 
     const handleAddOrEdit = async () => {
-        if (!monthYear || !interest || !balance || !accountId) return;
+        if (!monthYear || !interest || !accountId) return;
 
         // Convert "YYYY-MM" to a Date object. Use the 1st of the month, or the end of the month?
         // Let's use the 1st of the month
@@ -30,7 +28,6 @@ export function InterestLedger({ accountId }: InterestLedgerProps) {
             await updateInterestAccrual(editingId, {
                 accountId,
                 date,
-                balance: parseFloat(balance),
                 interestAccrued: parseFloat(interest),
             });
             setEditingId(null);
@@ -38,14 +35,12 @@ export function InterestLedger({ accountId }: InterestLedgerProps) {
             await addInterestAccrual({
                 accountId,
                 date,
-                balance: parseFloat(balance),
                 interestAccrued: parseFloat(interest),
             });
         }
 
         setInterest('');
         setMonthYear('');
-        setBalance('');
     };
 
     const handleEditClick = (accrual: InterestAccrual) => {
@@ -56,7 +51,6 @@ export function InterestLedger({ accountId }: InterestLedgerProps) {
         const month = String(dateObj.getMonth() + 1).padStart(2, '0');
 
         setMonthYear(`${year}-${month}`);
-        setBalance(accrual.balance.toString());
         setInterest(accrual.interestAccrued.toString());
     };
 
@@ -64,7 +58,6 @@ export function InterestLedger({ accountId }: InterestLedgerProps) {
         setEditingId(null);
         setInterest('');
         setMonthYear('');
-        setBalance('');
     };
 
     const formatMonthYear = (timestamp: number) => {
@@ -79,7 +72,7 @@ export function InterestLedger({ accountId }: InterestLedgerProps) {
                     <h3 className="font-bold text-slate-900 dark:text-slate-100 text-lg">
                         Monthly Interest History
                     </h3>
-                    <p className="text-sm text-slate-400">Track accruals and balance growth over time</p>
+                    <p className="text-sm text-slate-400">Track accruals over time</p>
                 </div>
                 <span className="bg-[#bdf3d5] text-[#139454] px-3 py-1 rounded-full text-xs font-bold tracking-wider">
                     LEDGER
@@ -89,7 +82,7 @@ export function InterestLedger({ accountId }: InterestLedgerProps) {
             {/* Add New Entry Form */}
             <div className="p-5 border-b border-slate-100 dark:border-primary/10">
                 <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-4">
-                    <div className="sm:col-span-2 min-w-0 w-full">
+                    <div className="min-w-0 w-full">
                         <label className="block text-xs font-bold text-slate-400 uppercase tracking-wider mb-2">Month & Year</label>
                         <DateInput
                             type="month"
@@ -97,20 +90,6 @@ export function InterestLedger({ accountId }: InterestLedgerProps) {
                             value={monthYear}
                             onChange={(e) => setMonthYear(e.target.value)}
                         />
-                    </div>
-                    <div className="min-w-0 w-full">
-                        <label className="block text-xs font-bold text-slate-400 uppercase tracking-wider mb-2">Month-End Balance</label>
-                        <div className="relative">
-                            <span className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400 font-medium text-sm">£</span>
-                            <input
-                                type="number"
-                                step="0.01"
-                                placeholder="0.00"
-                                className="w-full h-11 pl-7 pr-3 rounded-xl bg-white dark:bg-primary/10 border border-slate-200 dark:border-primary/20 focus:border-primary focus:ring-1 focus:ring-primary outline-none text-sm text-slate-900 dark:text-slate-100 placeholder-slate-400"
-                                value={balance}
-                                onChange={(e) => setBalance(e.target.value)}
-                            />
-                        </div>
                     </div>
                     <div className="min-w-0 w-full">
                         <label className="block text-xs font-bold text-slate-400 uppercase tracking-wider mb-2">Interest Amount</label>
@@ -130,7 +109,7 @@ export function InterestLedger({ accountId }: InterestLedgerProps) {
                 <div className="flex gap-2">
                     <button
                         onClick={handleAddOrEdit}
-                        disabled={!interest || !monthYear || !balance}
+                        disabled={!interest || !monthYear}
                         className="flex-1 h-12 rounded-xl bg-[#1ce86f] text-slate-900 font-bold text-sm hover:brightness-105 active:scale-[0.98] transition-all flex items-center justify-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
                     >
                         <Icon name={editingId ? "save" : "add_circle"} className="text-[18px]" />
@@ -162,9 +141,6 @@ export function InterestLedger({ accountId }: InterestLedgerProps) {
                                 <div>
                                     <div className="font-bold text-slate-900 dark:text-slate-100 text-base mb-1">
                                         {formatMonthYear(accrual.date)}
-                                    </div>
-                                    <div className="text-sm text-slate-400">
-                                        Statement Balance: £{accrual.balance.toLocaleString('en-GB', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
                                     </div>
                                 </div>
                                 <div className="flex items-center gap-6">

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -122,7 +122,6 @@ export interface InterestAccrual {
     id: string; // UUID
     accountId: string; // FK to Account.id
     date: number; // timestamp
-    balance: number; // Recorded balance at the time of accrual
     interestAccrued: number;
     updatedAt?: number;
 }
@@ -415,7 +414,6 @@ export const getSanitizedDbData = async (): Promise<Record<string, any[]>> => {
     if (rawData.interestAccruals) {
         rawData.interestAccruals = rawData.interestAccruals.map(a => ({
             ...a,
-            balance: Number(a.balance) || 0,
             interestAccrued: Number(a.interestAccrued) || 0,
             date: Number(a.date) || 0,
         }));

--- a/src/pages/AddAccountPage.tsx
+++ b/src/pages/AddAccountPage.tsx
@@ -277,7 +277,7 @@ export function AddAccountPage() {
 
                 {formData.interestTrackingMethod === 'manual' && (
                     <aside className="w-full xl:w-[calc(60%-1rem)]">
-                        <InterestLedger accountId={activeAccountId} currentBalance={parseFloat(formData.balance) || 0} />
+                        <InterestLedger accountId={activeAccountId} />
                     </aside>
                 )}
             </div>

--- a/src/pages/EditAccountPage.tsx
+++ b/src/pages/EditAccountPage.tsx
@@ -282,7 +282,7 @@ export function EditAccountPage() {
 
                 {formData.interestTrackingMethod === 'manual' && (
                     <aside className="w-full xl:w-[calc(60%-1rem)]">
-                        <InterestLedger accountId={activeAccountId} currentBalance={parseFloat(formData.balance) || 0} />
+                        <InterestLedger accountId={activeAccountId} />
                     </aside>
                 )}
             </div>

--- a/src/utils/interestCalculations.test.ts
+++ b/src/utils/interestCalculations.test.ts
@@ -30,9 +30,9 @@ describe('calculateProjectedAnnualInterest', () => {
             });
 
             const accruals: InterestAccrual[] = [
-                { id: '1', accountId: 'acc1', date: new Date(2024, 4, 6).getTime(), interestAccrued: 10, balance: 1000 }, // May 2024
-                { id: '2', accountId: 'acc1', date: new Date(2024, 5, 6).getTime(), interestAccrued: 10, balance: 1000 }, // June 2024
-                { id: '3', accountId: 'acc1', date: new Date(2024, 6, 6).getTime(), interestAccrued: 15, balance: 1000 }, // July 2024
+                { id: '1', accountId: 'acc1', date: new Date(2024, 4, 6).getTime(), interestAccrued: 10}, // May 2024
+                { id: '2', accountId: 'acc1', date: new Date(2024, 5, 6).getTime(), interestAccrued: 10}, // June 2024
+                { id: '3', accountId: 'acc1', date: new Date(2024, 6, 6).getTime(), interestAccrued: 15}, // July 2024
             ];
 
             const result = calculateProjectedAnnualInterest(account, accruals, taxYearStartTs, taxYearEndTs);
@@ -51,10 +51,10 @@ describe('calculateProjectedAnnualInterest', () => {
             });
 
             const accruals: InterestAccrual[] = [
-                { id: '1', accountId: 'acc1', date: new Date(2024, 4, 6).getTime(), interestAccrued: 10, balance: 1000 }, // May 2024
-                { id: '2', accountId: 'acc1', date: new Date(2024, 5, 6).getTime(), interestAccrued: 10, balance: 1000 }, // June 2024
-                { id: '3', accountId: 'acc1', date: new Date(2024, 6, 6).getTime(), interestAccrued: 10, balance: 1000 }, // July 2024
-                { id: '4', accountId: 'acc1', date: new Date(2024, 7, 6).getTime(), interestAccrued: 20, balance: 1000 }, // Aug 2024
+                { id: '1', accountId: 'acc1', date: new Date(2024, 4, 6).getTime(), interestAccrued: 10}, // May 2024
+                { id: '2', accountId: 'acc1', date: new Date(2024, 5, 6).getTime(), interestAccrued: 10}, // June 2024
+                { id: '3', accountId: 'acc1', date: new Date(2024, 6, 6).getTime(), interestAccrued: 10}, // July 2024
+                { id: '4', accountId: 'acc1', date: new Date(2024, 7, 6).getTime(), interestAccrued: 20}, // Aug 2024
             ];
 
             const result = calculateProjectedAnnualInterest(account, accruals, taxYearStartTs, taxYearEndTs);
@@ -90,7 +90,7 @@ describe('calculateProjectedAnnualInterest', () => {
             });
 
             const accruals: InterestAccrual[] = [
-                { id: '1', accountId: 'acc1', date: new Date(2024, 11, 1).getTime(), interestAccrued: 60, balance: 1000 }
+                { id: '1', accountId: 'acc1', date: new Date(2024, 11, 1).getTime(), interestAccrued: 60 }
             ];
 
             const result = calculateProjectedAnnualInterest(account, accruals, taxYearStartTs, taxYearEndTs);


### PR DESCRIPTION
Remove unused "month-end balance" field from manual interest entries as requested by user.

---
*PR created automatically by Jules for task [13248849853185439707](https://jules.google.com/task/13248849853185439707) started by @John-Bell*