### PR TITLE
Fix annual budget display and transaction filtering on dashboard

### DIFF
--- a/src/components/dashboard/DashboardAccountList.tsx
+++ b/src/components/dashboard/DashboardAccountList.tsx
@@ -28,11 +28,14 @@ export function DashboardAccountList({ accounts, budgets, transactions }: Dashbo
         return budgets.filter(b => b.accountId === accountId);
     };
 
-    const getTransactionsForBudget = (budgetId: string) => {
+    const getTransactionsForBudget = (budgetId: string, frequency?: string) => {
         return transactions.filter(t => {
             if (t.type !== 'expense') return false;
             if (t.budgetId !== budgetId) return false;
             const d = new Date(t.date);
+            if (frequency === 'annual') {
+                return d.getFullYear() === currentYear;
+            }
             return d.getMonth() === currentMonth && d.getFullYear() === currentYear;
         }).sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime());
     };
@@ -83,12 +86,12 @@ export function DashboardAccountList({ accounts, budgets, transactions }: Dashbo
                         const accountBudgets = getBudgetsForAccount(account.id);
                         // const accountTotalBalance = account.balance; // Removed unused variable
                         const accountTotalAllocated = accountBudgets.reduce((sum, budget) => {
-                            return sum + (budget.frequency === 'annual' ? budget.amount / 12 : budget.amount);
+                            return sum + budget.amount;
                         }, 0);
 
                         let totalSpent = 0;
                         accountBudgets.forEach(budget => {
-                            const budgetTransactions = getTransactionsForBudget(budget.id);
+                            const budgetTransactions = getTransactionsForBudget(budget.id, budget.frequency);
                             totalSpent += budgetTransactions.reduce((sum, t) => sum + t.amount, 0);
                         });
 
@@ -114,9 +117,9 @@ export function DashboardAccountList({ accounts, budgets, transactions }: Dashbo
 
                                 {/* Budgets & Transactions */}
                                 {accountBudgets.map(budget => {
-                                    const budgetTransactions = getTransactionsForBudget(budget.id);
+                                    const budgetTransactions = getTransactionsForBudget(budget.id, budget.frequency);
                                     const budgetTotalSpent = budgetTransactions.reduce((sum, t) => sum + t.amount, 0);
-                                    const budgetTarget = budget.frequency === 'annual' ? budget.amount / 12 : budget.amount;
+                                    const budgetTarget = budget.amount;
 
                                     return (
                                         <div key={budget.id} className="flex flex-col border-b border-slate-100 dark:border-slate-800/50 last:border-0">
@@ -186,7 +189,7 @@ export function DashboardAccountList({ accounts, budgets, transactions }: Dashbo
                     const accountBudgets = getBudgetsForAccount(account.id);
                     const accountTotalBalance = account.balance;
                     const accountTotalAllocated = accountBudgets.reduce((sum, budget) => {
-                        return sum + (budget.frequency === 'annual' ? budget.amount / 12 : budget.amount);
+                        return sum + budget.amount;
                     }, 0);
 
                     return (
@@ -222,11 +225,10 @@ export function DashboardAccountList({ accounts, budgets, transactions }: Dashbo
                             {accountBudgets.length > 0 ? (
                                 <div className="flex flex-col gap-2 mt-2">
                                     {accountBudgets.map(budget => {
-                                        const budgetTransactions = getTransactionsForBudget(budget.id);
+                                        const budgetTransactions = getTransactionsForBudget(budget.id, budget.frequency);
                                         const budgetTotalSpent = budgetTransactions.reduce((sum, t) => sum + t.amount, 0);
 
-                                        // Assuming monthly budget for display
-                                        const budgetTarget = budget.frequency === 'annual' ? budget.amount / 12 : budget.amount;
+                                        const budgetTarget = budget.amount;
 
                                         return (
                                             <div key={budget.id} className="flex flex-col gap-3 py-2">

--- a/tests/dashboard-annual-budget.spec.ts
+++ b/tests/dashboard-annual-budget.spec.ts
@@ -1,0 +1,155 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Dashboard Annual Budget', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/incometrack/');
+    // Wait for the app to load and initialize DB
+    await page.waitForFunction(() => (window as any).__DEXIE_DB__ !== undefined);
+
+    await page.evaluate(async () => {
+      const db = (window as any).__DEXIE_DB__;
+      await db.profile.put({
+        id: 'default',
+        name: 'Test User',
+        partner1Name: 'P1',
+        partner2Name: 'P2',
+        createdAt: Date.now()
+      });
+
+      const accountId = 'acc-1';
+      await db.accounts.put({
+        id: accountId,
+        ownerId: 'p1',
+        name: 'Main Account',
+        balance: 5000,
+        interestRate: 0,
+        category: 'Cash',
+        updatedAt: Date.now()
+      });
+
+      const now = new Date();
+      const currentMonth = now.getMonth();
+      const currentYear = now.getFullYear();
+
+      // Monthly Budget
+      const monthlyBudgetId = 'budget-monthly';
+      await db.budgets.put({
+        id: monthlyBudgetId,
+        accountId: accountId,
+        name: 'Monthly Food',
+        amount: 100,
+        frequency: 'monthly',
+        updatedAt: Date.now()
+      });
+
+      // Annual Budget
+      const annualBudgetId = 'budget-annual';
+      await db.budgets.put({
+        id: annualBudgetId,
+        accountId: accountId,
+        name: 'Annual Car Insurance',
+        amount: 1200,
+        frequency: 'annual',
+        updatedAt: Date.now()
+      });
+
+      // Transactions for Monthly Budget
+      // 1. Current month (should show)
+      await db.transactions.put({
+        id: 't-m-1',
+        date: new Date(currentYear, currentMonth, 15).getTime(),
+        payee: 'Current Month Grocery',
+        amount: 25,
+        type: 'expense',
+        budgetId: monthlyBudgetId,
+        accountId: accountId,
+        updatedAt: Date.now()
+      });
+      // 2. Previous month (should NOT show)
+      const prevMonth = currentMonth === 0 ? 11 : currentMonth - 1;
+      const yearForPrevMonth = currentMonth === 0 ? currentYear - 1 : currentYear;
+      await db.transactions.put({
+        id: 't-m-2',
+        date: new Date(yearForPrevMonth, prevMonth, 15).getTime(),
+        payee: 'Prev Month Grocery',
+        amount: 30,
+        type: 'expense',
+        budgetId: monthlyBudgetId,
+        accountId: accountId,
+        updatedAt: Date.now()
+      });
+
+      // Transactions for Annual Budget
+      // 1. Current month (should show)
+      await db.transactions.put({
+        id: 't-a-1',
+        date: new Date(currentYear, currentMonth, 10).getTime(),
+        payee: 'Car Service',
+        amount: 100,
+        type: 'expense',
+        budgetId: annualBudgetId,
+        accountId: accountId,
+        updatedAt: Date.now()
+      });
+      // 2. Previous month of same year (should show if frequency is annual)
+      // If current month is Jan, we use Feb of same year for the test logic or just use another day in Jan if we want to be safe,
+      // but the requirement says "calendar year".
+      // Let's pick a month that is definitely in the same calendar year.
+      let targetMonth = currentMonth > 0 ? 0 : 1; // If Jan, use Feb. Else use Jan.
+      await db.transactions.put({
+        id: 't-a-2',
+        date: new Date(currentYear, targetMonth, 5).getTime(),
+        payee: 'Car Tax',
+        amount: 200,
+        type: 'expense',
+        budgetId: annualBudgetId,
+        accountId: accountId,
+        updatedAt: Date.now()
+      });
+      // 3. Previous year (should NOT show)
+      await db.transactions.put({
+        id: 't-a-3',
+        date: new Date(currentYear - 1, 6, 1).getTime(),
+        payee: 'Last Year Insurance',
+        amount: 1000,
+        type: 'expense',
+        budgetId: annualBudgetId,
+        accountId: accountId,
+        updatedAt: Date.now()
+      });
+    });
+
+    await page.reload();
+  });
+
+  test('should display annual budgets correctly on dashboard', async ({ page }) => {
+    // Wait for data to be loaded
+    await expect(page.getByText('Main Account').first()).toBeVisible();
+
+    // Check Monthly Budget
+    const monthlyBudgetContainer = page.locator('div').filter({ hasText: /Monthly Food/ }).first();
+    await expect(monthlyBudgetContainer).toBeVisible();
+
+    // Budgeted: 100.00
+    // Spent: 25.00
+    // Remaining: 75.00
+    await expect(page.getByText('100.00').first()).toBeVisible();
+    await expect(page.getByText('75.00').first()).toBeVisible();
+    await expect(page.getByText('Current Month Grocery').first()).toBeVisible();
+    await expect(page.getByText('Prev Month Grocery')).not.toBeVisible();
+
+    // Check Annual Budget
+    const annualBudgetContainer = page.locator('div').filter({ hasText: /Annual Car Insurance/ }).first();
+    await expect(annualBudgetContainer).toBeVisible();
+
+    // Budgeted: 1,200.00
+    // Spent: 100 + 200 = 300
+    // Remaining: 1200 - 300 = 900.00
+    await expect(page.getByText('1,200.00').first()).toBeVisible();
+    await expect(page.getByText('900.00').first()).toBeVisible();
+
+    await expect(page.getByText('Car Service').first()).toBeVisible();
+    await expect(page.getByText('Car Tax').first()).toBeVisible();
+    await expect(page.getByText('Last Year Insurance')).not.toBeVisible();
+  });
+});


### PR DESCRIPTION
This change ensures that annual budgets on the dashboard show the total yearly budget and aggregate all expenses from the current calendar year, while maintaining the monthly view for monthly budgets. This aligns the dashboard display with the intended tracking for annual budget items.

Fixes #180

---
*PR created automatically by Jules for task [14138947854710712692](https://jules.google.com/task/14138947854710712692) started by @John-Bell*