### PR TITLE
Fix Interest Calculation and Tax Year Reactivity

### DIFF
--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useLiveQuery } from 'dexie-react-hooks';
 import { db } from '../lib/db';
+import { useStore } from '@/store/useStore';
 import { AppLayout } from '../components/layout/AppLayout';
 import { Header } from '../components/layout/Header';
 import { Icon } from '../components/ui/Icon';
@@ -9,6 +10,7 @@ import { MainHeaderActions } from '../components/layout/MainHeaderActions';
 
 export function SettingsPage() {
     const navigate = useNavigate();
+    const { setTaxYear } = useStore();
 
     const settings = useLiveQuery(() => db.settings.toArray());
     const taxRules = useLiveQuery(() => db.taxRules.toArray());
@@ -27,6 +29,7 @@ export function SettingsPage() {
     const handleTaxYearChange = async (e: React.ChangeEvent<HTMLSelectElement>) => {
         if (currentSettings) {
             await db.settings.update(currentSettings.id, { taxYear: e.target.value });
+            setTaxYear(e.target.value);
         }
     };
 

--- a/src/store/useStore.ts
+++ b/src/store/useStore.ts
@@ -16,6 +16,7 @@ export interface AppState {
     initStore: () => Promise<void>;
     setProfile: (profile: Profile) => Promise<void>;
     setActiveAccountsTab: (tab: string) => void;
+    setTaxYear: (taxYear: string) => void;
     setSyncStatus: (status: 'disconnected' | 'connected' | 'permission_needed') => void;
     setLastSynced: (timestamp: number | null) => void;
 }
@@ -79,6 +80,7 @@ export const useStore = create<AppState>()((set) => ({
     },
 
     setActiveAccountsTab: (tab: string) => set({ activeAccountsTab: tab }),
+    setTaxYear: (taxYear: string) => set({ taxYear }),
     setSyncStatus: (status: 'disconnected' | 'connected' | 'permission_needed') => set({ syncStatus: status }),
     setLastSynced: (timestamp: number | null) => set({ lastSynced: timestamp })
 }));

--- a/src/utils/interestCalculations.ts
+++ b/src/utils/interestCalculations.ts
@@ -44,11 +44,6 @@ export const calculateProjectedAnnualInterest = (
         return fullYearInterest;
     }
 
-    // If there IS a payout date (maturity date) that is outside the tax year,
-    // the interest should be 0 because the monthly payout or maturity doesn't occur in this year.
-    if (payoutTs < taxYearStartTs || payoutTs > taxYearEndTs) {
-        return 0;
-    }
 
     // If there IS a payout date that cuts off during the tax year (e.g. a monthly fix maturing), pro-rate the AER.
     const start = new Date(taxYearStartTs);

--- a/tests/interest-tax-year.spec.ts
+++ b/tests/interest-tax-year.spec.ts
@@ -1,0 +1,111 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Interest Tax Year Filtering', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/incometrack/');
+    await page.waitForFunction(() => (window as any).__DEXIE_DB__ !== undefined);
+
+    await page.evaluate(async () => {
+      const db = (window as any).__DEXIE_DB__;
+      await db.profile.put({
+        id: 'default',
+        name: 'Test User',
+        partner1Name: 'P1',
+        partner2Name: 'P2',
+        createdAt: Date.now()
+      });
+
+      await db.settings.put({
+        id: 'default',
+        currency: 'GBP',
+        taxYear: '2024-2025',
+        icloudSync: false,
+        updatedAt: Date.now()
+      });
+    });
+    await page.reload();
+  });
+
+  test('should show correct AER interest for monthly account maturing in future year', async ({ page }) => {
+    await page.evaluate(async () => {
+      const db = (window as any).__DEXIE_DB__;
+
+      // Account maturing in Jan 2026 (outside 2024-2025 which ends April 2025)
+      await db.accounts.put({
+        id: 'acc-aer-future',
+        ownerId: 'person1',
+        name: 'Future Maturity',
+        balance: 10000,
+        interestRate: 5.0,
+        interestTrackingMethod: 'aer',
+        interestPayoutFrequency: 'monthly',
+        interestPayoutDate: new Date(2026, 0, 1).getTime(), // Jan 2026
+        category: 'Easy Access Savings',
+        updatedAt: Date.now()
+      });
+    });
+
+    await page.goto('/incometrack/accounts');
+    await page.click('button:has-text("P1")'); // Select P1 tab
+
+    // 2024-2025 should show 12 months of 5% on 10000 = £500
+    // Currently, it might show nothing because of the bug I suspect.
+    await expect(page.getByText('+ £500.00 interest this year')).toBeVisible();
+  });
+
+  test('should update interest when tax year is changed in settings', async ({ page }) => {
+     // Setup manual interest for 2024-2025 and 2025-2026
+     await page.evaluate(async () => {
+      const db = (window as any).__DEXIE_DB__;
+      const accId = 'acc-manual';
+      await db.accounts.put({
+        id: accId,
+        ownerId: 'person1',
+        name: 'Manual Account',
+        balance: 1000,
+        interestRate: 0,
+        interestTrackingMethod: 'manual',
+        category: 'Easy Access Savings',
+        updatedAt: Date.now()
+      });
+
+      // Accrual in 2024-2025 (e.g. May 2024)
+      await db.interestAccruals.put({
+        id: 'accrual-1',
+        accountId: accId,
+        date: new Date(2024, 4, 10).getTime(),
+        interestAccrued: 100,
+        updatedAt: Date.now()
+      });
+
+      // Accrual in 2025-2026 (e.g. May 2025)
+      await db.interestAccruals.put({
+        id: 'accrual-2',
+        accountId: accId,
+        date: new Date(2025, 4, 10).getTime(),
+        interestAccrued: 200,
+        updatedAt: Date.now()
+      });
+    });
+
+    await page.goto('/incometrack/accounts');
+    await page.click('button:has-text("P1")');
+    await expect(page.getByText('+ £100.00 interest this year')).toBeVisible();
+
+    // Change tax year to 2025-2026
+    await page.goto('/incometrack/settings');
+    await page.locator('select').selectOption('2025-2026');
+
+    // Wait for DB to be updated
+    await page.waitForFunction(async (expectedYear) => {
+      const db = (window as any).__DEXIE_DB__;
+      const settings = await db.settings.get('default');
+      return settings?.taxYear === expectedYear;
+    }, '2025-2026');
+
+    await page.goto('/incometrack/accounts');
+    await page.click('button:has-text("P1")');
+    // If it's not reactive, it will still show £100.00
+    await expect(page.getByText('+ £200.00 interest this year')).toBeVisible();
+  });
+});


### PR DESCRIPTION
The 'interest this year' value on the account page was incorrect because monthly accounts maturing in a future tax year were having their interest zeroed out. Additionally, changing the tax year in settings did not immediately update the UI on other pages.

I have:
1. Fixed the logic in `calculateProjectedAnnualInterest` to remove the incorrect zeroing of interest for monthly accounts.
2. Enhanced the global store with a `setTaxYear` action to allow components to react to tax year changes immediately.
3. Updated the Settings page to use this new action.
4. Verified the changes with a comprehensive Playwright test.

Fixes #184

---
*PR created automatically by Jules for task [7142976157420946563](https://jules.google.com/task/7142976157420946563) started by @John-Bell*