### PR TITLE
Configure PWA Workbox to cache Google Fonts

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -42,6 +42,31 @@ export default defineConfig({
             type: 'image/png'
           }
         ]
+      },
+      workbox: {
+        runtimeCaching: [
+          {
+            urlPattern: /^https:\/\/fonts\.googleapis\.com\/.*/i,
+            handler: 'StaleWhileRevalidate',
+            options: {
+              cacheName: 'google-fonts-stylesheets',
+            },
+          },
+          {
+            urlPattern: /^https:\/\/fonts\.gstatic\.com\/.*/i,
+            handler: 'CacheFirst',
+            options: {
+              cacheName: 'google-fonts-webfonts',
+              expiration: {
+                maxEntries: 30,
+                maxAgeSeconds: 60 * 60 * 24 * 365, // 365 days
+              },
+              cacheableResponse: {
+                statuses: [0, 200],
+              },
+            },
+          },
+        ],
       }
     })
   ],


### PR DESCRIPTION
Added `workbox.runtimeCaching` to the `VitePWA` plugin config in `vite.config.ts`.
Configures `StaleWhileRevalidate` strategy for `fonts.googleapis.com` stylesheets and `CacheFirst` strategy for `fonts.gstatic.com` webfonts (with a 365-day max age and 30 entry limit).
This fixes the issue where Material Symbols icons would disappear when the app was offline.

---
*PR created automatically by Jules for task [10611312967701074090](https://jules.google.com/task/10611312967701074090) started by @John-Bell*