### PR TITLE
fix: ensure interest rate and compound toggle are always visible in account form

### DIFF
--- a/src/hooks/useAccountForm.ts
+++ b/src/hooks/useAccountForm.ts
@@ -102,9 +102,9 @@ export function useAccountForm(accountId?: string) {
 
     const handleSave = async () => {
         if (!formData.accountName || !formData.balance || !formData.category) return;
-        if (showAER && formData.interestTrackingMethod === 'aer' && !formData.interestRate) return;
+        if (showAER && !formData.interestRate) return;
 
-        const finalInterestRate = showAER && formData.interestTrackingMethod === 'aer'
+        const finalInterestRate = showAER
             ? parseFloat(formData.interestRate)
             : 0;
 

--- a/src/pages/AddAccountPage.tsx
+++ b/src/pages/AddAccountPage.tsx
@@ -135,7 +135,7 @@ export function AddAccountPage() {
                 )}
 
                 {/* Balance and Interest Rate Fields */}
-                <div className={showAER && formData.interestTrackingMethod === 'aer' ? "grid grid-cols-2 gap-4 items-start" : "space-y-2"}>
+                <div className={showAER ? "grid grid-cols-2 gap-4 items-start" : "space-y-2"}>
                     <div className="space-y-2">
                         <label className="block text-sm font-semibold text-slate-600 dark:text-slate-400">Current Balance</label>
                         <div className="relative flex items-center">
@@ -150,7 +150,7 @@ export function AddAccountPage() {
                         </div>
                     </div>
 
-                    {showAER && formData.interestTrackingMethod === 'aer' && (
+                    {showAER && (
                         <div className="space-y-2">
                             <label className="block text-sm font-semibold text-slate-600 dark:text-slate-400">Interest Rate (%)</label>
                             <div className="relative flex items-center">
@@ -168,11 +168,11 @@ export function AddAccountPage() {
                     )}
 
                     {/* Compound Interest Toggle */}
-                    {showAER && formData.interestTrackingMethod === 'aer' && (
+                    {showAER && (
                         <div className="flex items-center justify-between p-4 rounded-xl border border-primary/20 bg-white dark:bg-primary/5">
                             <div>
                                 <p className="font-bold text-slate-900 dark:text-slate-100">Compounds Interest?</p>
-                                <p className="text-xs text-slate-500">Enable for AER or compounding standard rates</p>
+                                <p className="text-xs text-slate-500">Leave checked if interest stays in this account. Uncheck if interest pays out to another account.</p>
                             </div>
                             <label className="relative inline-flex items-center cursor-pointer">
                                 <input
@@ -305,7 +305,7 @@ export function AddAccountPage() {
             <footer className="p-4 bg-background-light dark:bg-background-dark border-t border-primary/10 space-y-3">
                 <button
                     onClick={handleSave}
-                    disabled={!formData.accountName || !formData.balance || (showAER && formData.interestTrackingMethod === 'aer' && !formData.interestRate) || !formData.category}
+                    disabled={!formData.accountName || !formData.balance || (showAER && !formData.interestRate) || !formData.category}
                     className="w-full py-4 rounded-xl bg-primary text-background-dark font-bold text-lg hover:brightness-110 active:scale-[0.98] transition-all shadow-lg shadow-primary/20 disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                     Add Account

--- a/src/pages/EditAccountPage.tsx
+++ b/src/pages/EditAccountPage.tsx
@@ -142,7 +142,7 @@ export function EditAccountPage() {
                 )}
 
                 {/* Balance and Interest Rate Fields */}
-                <div className={isEligibleForAER && formData.interestTrackingMethod === 'aer' ? "grid grid-cols-2 gap-4 items-start" : "space-y-2"}>
+                <div className={isEligibleForAER ? "grid grid-cols-2 gap-4 items-start" : "space-y-2"}>
                     <div className="space-y-2">
                         <label className="block text-sm font-semibold text-slate-600 dark:text-slate-400">Current Balance</label>
                         <div className="relative flex items-center">
@@ -156,7 +156,7 @@ export function EditAccountPage() {
                         </div>
                     </div>
 
-                    {isEligibleForAER && formData.interestTrackingMethod === 'aer' && (
+                    {isEligibleForAER && (
                         <div className="space-y-2">
                             <label className="block text-sm font-semibold text-slate-600 dark:text-slate-400">Interest Rate (%)</label>
                             <div className="relative flex items-center">
@@ -173,11 +173,11 @@ export function EditAccountPage() {
                     )}
 
                     {/* Compound Interest Toggle */}
-                    {isEligibleForAER && formData.interestTrackingMethod === 'aer' && (
+                    {isEligibleForAER && (
                         <div className="flex items-center justify-between p-4 rounded-xl border border-primary/20 bg-white dark:bg-primary/5">
                             <div>
                                 <p className="font-bold text-slate-900 dark:text-slate-100">Compounds Interest?</p>
-                                <p className="text-xs text-slate-500">Enable for AER or compounding standard rates</p>
+                                <p className="text-xs text-slate-500">Leave checked if interest stays in this account. Uncheck if interest pays out to another account.</p>
                             </div>
                             <label className="relative inline-flex items-center cursor-pointer">
                                 <input
@@ -310,7 +310,7 @@ export function EditAccountPage() {
             <footer className="p-4 bg-background-light dark:bg-background-dark border-t border-primary/10 space-y-3">
                 <button
                     onClick={handleSave}
-                    disabled={!formData.accountName || !formData.balance || (isEligibleForAER && formData.interestTrackingMethod === 'aer' && !formData.interestRate) || !formData.category}
+                    disabled={!formData.accountName || !formData.balance || (isEligibleForAER && !formData.interestRate) || !formData.category}
                     className="w-full py-4 rounded-xl bg-primary text-background-dark font-bold text-lg hover:brightness-110 active:scale-[0.98] transition-all shadow-lg shadow-primary/20 disabled:opacity-50 disabled:cursor-not-allowed"
                 >
                     Save Changes


### PR DESCRIPTION
This PR updates the Add and Edit Account forms so that the "Interest Rate (%)" input and the "Compounds Interest?" toggle are always visible, editable, and saved for eligible accounts, even if "Manual Ledger" tracking is selected. This allows the Hybrid Interest Forecasting Engine to utilize the interest rate to generate forward-looking projections for manually tracked accounts. Form validation and state management have been updated to support this new behavior.

---
*PR created automatically by Jules for task [3229135734909546845](https://jules.google.com/task/3229135734909546845) started by @John-Bell*