### PR TITLE
feat: enforce hybrid interest tracking on account forms

### DIFF
--- a/src/hooks/useAccountForm.ts
+++ b/src/hooks/useAccountForm.ts
@@ -85,12 +85,6 @@ export function useAccountForm(accountId?: string) {
     const showBonus = canShowBonus(formData.category as AccountCategory);
 
     useEffect(() => {
-        if (!showAER && formData.interestTrackingMethod !== 'manual') {
-            handleChange('interestTrackingMethod', 'manual');
-        }
-    }, [showAER, formData.interestTrackingMethod]);
-
-    useEffect(() => {
         if (formData.category !== 'Current Account' && formData.budgetOrder !== '') {
             handleChange('budgetOrder', '');
         }
@@ -116,7 +110,7 @@ export function useAccountForm(accountId?: string) {
             category: formData.category,
             balance: parseFloat(formData.balance),
             interestRate: finalInterestRate,
-            interestTrackingMethod: showAER ? formData.interestTrackingMethod : 'manual',
+            interestTrackingMethod: 'manual' as const,
             budgetOrder: formData.budgetOrder !== '' ? parseInt(formData.budgetOrder, 10) : undefined,
             bonusRateActive: showBonus ? formData.bonusRateActive : false,
             bonusEndDate: showBonus && formData.bonusRateActive && formData.bonusEndDate

--- a/src/pages/AddAccountPage.tsx
+++ b/src/pages/AddAccountPage.tsx
@@ -31,7 +31,7 @@ export function AddAccountPage() {
             </header>
 
             <div className="flex-1 overflow-y-auto p-4 lg:p-6 flex flex-col xl:flex-row gap-8">
-                <main className={`space-y-6 ${formData.interestTrackingMethod === 'manual' ? 'xl:w-[calc(40%-1rem)]' : 'flex-1'}`}>
+                <main className={`space-y-6 ${showAER ? 'xl:w-[calc(40%-1rem)]' : 'flex-1'}`}>
                     <h2 className="text-xs font-bold text-slate-400 uppercase tracking-wider mb-2">GENERAL INFORMATION</h2>
                 {/* Account Name Field */}
                 <div className="space-y-2">
@@ -104,35 +104,6 @@ export function AddAccountPage() {
                 )}
 
                 <h2 className="text-xs font-bold text-slate-400 uppercase tracking-wider mt-8 mb-4">FINANCIAL SETTINGS</h2>
-
-                {/* Calculation Method Field */}
-                {showAER && (
-                    <div className="space-y-2">
-                        <label className="block text-sm font-semibold text-slate-600 dark:text-slate-400">Calculation Method</label>
-                        <div className="flex bg-slate-100 dark:bg-primary/10 rounded-lg p-1">
-                            <button
-                                onClick={() => handleChange('interestTrackingMethod', 'aer')}
-                                className={`flex-1 py-3 text-sm font-semibold rounded-md transition-all ${
-                                    formData.interestTrackingMethod === 'aer'
-                                        ? 'bg-white dark:bg-background-dark text-slate-900 dark:text-slate-100 shadow-sm'
-                                        : 'text-slate-500 hover:text-slate-700 dark:text-slate-400'
-                                }`}
-                            >
-                                AER (%)
-                            </button>
-                            <button
-                                onClick={() => handleChange('interestTrackingMethod', 'manual')}
-                                className={`flex-1 py-3 text-sm font-semibold rounded-md transition-all ${
-                                    formData.interestTrackingMethod === 'manual'
-                                        ? 'bg-white dark:bg-background-dark text-slate-900 dark:text-slate-100 shadow-sm'
-                                        : 'text-slate-500 hover:text-slate-700 dark:text-slate-400'
-                                }`}
-                            >
-                                Manual Ledger
-                            </button>
-                        </div>
-                    </div>
-                )}
 
                 {/* Balance and Interest Rate Fields */}
                 <div className={showAER ? "grid grid-cols-2 gap-4 items-start" : "space-y-2"}>
@@ -294,7 +265,7 @@ export function AddAccountPage() {
                 </div>
                 </main>
 
-                {formData.interestTrackingMethod === 'manual' && (
+                {showAER && (
                     <aside className="w-full xl:w-[calc(60%-1rem)]">
                         <InterestLedger accountId={activeAccountId} currentBalance={parseFloat(formData.balance) || 0} />
                     </aside>

--- a/src/pages/EditAccountPage.tsx
+++ b/src/pages/EditAccountPage.tsx
@@ -39,7 +39,7 @@ export function EditAccountPage() {
             </header>
 
             <div className="flex-1 overflow-y-auto p-4 lg:p-6 flex flex-col xl:flex-row gap-8">
-                <main className={`space-y-6 ${formData.interestTrackingMethod === 'manual' ? 'xl:w-[calc(40%-1rem)]' : 'flex-1'}`}>
+                <main className={`space-y-6 ${isEligibleForAER ? 'xl:w-[calc(40%-1rem)]' : 'flex-1'}`}>
                     <h2 className="text-xs font-bold text-slate-400 uppercase tracking-wider mb-2">GENERAL INFORMATION</h2>
                     {/* Account Name Field */}
                 <div className="space-y-2">
@@ -111,35 +111,6 @@ export function EditAccountPage() {
                 )}
 
                 <h2 className="text-xs font-bold text-slate-400 uppercase tracking-wider mt-8 mb-4">FINANCIAL SETTINGS</h2>
-
-                {/* Calculation Method Field */}
-                {isEligibleForAER && (
-                    <div className="space-y-2">
-                        <label className="block text-sm font-semibold text-slate-600 dark:text-slate-400">Calculation Method</label>
-                        <div className="flex bg-slate-100 dark:bg-primary/10 rounded-lg p-1">
-                            <button
-                                onClick={() => handleChange('interestTrackingMethod', 'aer')}
-                                className={`flex-1 py-3 text-sm font-semibold rounded-md transition-all ${
-                                    formData.interestTrackingMethod === 'aer'
-                                        ? 'bg-white dark:bg-background-dark text-slate-900 dark:text-slate-100 shadow-sm'
-                                        : 'text-slate-500 hover:text-slate-700 dark:text-slate-400'
-                                }`}
-                            >
-                                AER (%)
-                            </button>
-                            <button
-                                onClick={() => handleChange('interestTrackingMethod', 'manual')}
-                                className={`flex-1 py-3 text-sm font-semibold rounded-md transition-all ${
-                                    formData.interestTrackingMethod === 'manual'
-                                        ? 'bg-white dark:bg-background-dark text-slate-900 dark:text-slate-100 shadow-sm'
-                                        : 'text-slate-500 hover:text-slate-700 dark:text-slate-400'
-                                }`}
-                            >
-                                Manual Ledger
-                            </button>
-                        </div>
-                    </div>
-                )}
 
                 {/* Balance and Interest Rate Fields */}
                 <div className={isEligibleForAER ? "grid grid-cols-2 gap-4 items-start" : "space-y-2"}>
@@ -299,7 +270,7 @@ export function EditAccountPage() {
                 </div>
                 </main>
 
-                {formData.interestTrackingMethod === 'manual' && (
+                {isEligibleForAER && (
                     <aside className="w-full xl:w-[calc(60%-1rem)]">
                         <InterestLedger accountId={activeAccountId} currentBalance={parseFloat(formData.balance) || 0} />
                     </aside>


### PR DESCRIPTION
This PR addresses a user request to remove the "Calculation Method" toggle on the Add Account and Edit Account pages.

Because the system uses AER for forecasting but requires manual ledger entries for accuracy and handling fluctuating conditions, the requirement is to always show **both** the AER inputs (e.g. Interest Rate, Compound settings) and the Manual Ledger (accrued interest entry fields) at the same time for any eligible account.

Changes included:
*   **Removed the UI Toggle:** The "Calculation Method" toggle in `EditAccountPage.tsx` and `AddAccountPage.tsx` has been eliminated.
*   **Always-Visible Sections:** The main form now permanently displays AER fields for eligible accounts, while the `InterestLedger` `<aside>` is concurrently rendered alongside it without needing a toggle switch.
*   **Enforced Hybrid Tracking:** In `useAccountForm.ts`, the backend save logic now explicitly sets `interestTrackingMethod: 'manual'` to implicitly trigger the Hybrid Tracking calculation (using YTD manual accruals + AER projections) across the rest of the app.
*   **Tests passing:** Ensured all UI and calculation tests continue to pass correctly.

---
*PR created automatically by Jules for task [1793712335690056322](https://jules.google.com/task/1793712335690056322) started by @John-Bell*