### PR TITLE
Remove compact view from Budgets page

### DIFF
--- a/src/pages/BudgetsPage.tsx
+++ b/src/pages/BudgetsPage.tsx
@@ -10,7 +10,6 @@ import { Icon } from '../components/ui/Icon';
 export function BudgetsPage() {
     const navigate = useNavigate();
     const [viewMode, setViewMode] = useState<'monthly' | 'annual'>('monthly');
-    const [cardLayout, setCardLayout] = useState<'detailed' | 'compact'>('detailed');
 
     const budgets = useLiveQuery(() => db.budgets.toArray()) || [];
     const transactions = useLiveQuery(() => db.transactions.toArray()) || [];
@@ -55,32 +54,6 @@ export function BudgetsPage() {
                             >
                                 Annual View
                             </button>
-                        </div>
-                        <div className="mt-4 flex justify-end">
-                            <div className="flex bg-[#E8F8EE] dark:bg-[#1A2E22] rounded-xl p-1 shadow-sm border border-slate-200 dark:border-border-dark">
-                                <button
-                                    onClick={() => setCardLayout('detailed')}
-                                    className={`flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-bold transition-all ${
-                                        cardLayout === 'detailed'
-                                            ? 'bg-white dark:bg-surface-dark text-[#1DAF61] shadow-sm'
-                                            : 'text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-300'
-                                    }`}
-                                >
-                                    <Icon name="view_list" className="text-lg" />
-                                    Detailed
-                                </button>
-                                <button
-                                    onClick={() => setCardLayout('compact')}
-                                    className={`flex items-center gap-2 px-4 py-2 rounded-lg text-sm font-bold transition-all ${
-                                        cardLayout === 'compact'
-                                            ? 'bg-white dark:bg-surface-dark text-[#1DAF61] shadow-sm'
-                                            : 'text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-300'
-                                    }`}
-                                >
-                                    <Icon name="view_headline" className="text-lg" />
-                                    Compact
-                                </button>
-                            </div>
                         </div>
                     </div>
                 </div>
@@ -159,47 +132,6 @@ export function BudgetsPage() {
                                     status = 'PLENTY OF CAPACITY';
                                     barColor = 'bg-emerald-500';
                                     chipClass = 'bg-emerald-500/10 text-emerald-500';
-                                }
-
-                                if (cardLayout === 'compact') {
-                                    return (
-                                        <div key={budget.id} className="bg-white dark:bg-surface-dark p-4 rounded-xl shadow-sm border border-slate-200 dark:border-border-dark flex flex-col gap-3 relative overflow-hidden">
-                                            <div className="flex items-start gap-3">
-                                                <div className="w-10 h-10 rounded-xl bg-[#E8F8EE] dark:bg-[#1A2E22] flex items-center justify-center flex-shrink-0">
-                                                    <Icon name={budget.icon || "label"} className="text-[#1DAF61] text-xl" />
-                                                </div>
-                                                <div className="flex-1 flex flex-col min-w-0">
-                                                    <div className="flex justify-between items-center w-full">
-                                                        <h3 className="text-lg font-bold text-slate-900 dark:text-slate-100 truncate">{budget.name}</h3>
-                                                    </div>
-                                                    <div className="flex items-center text-xs text-slate-500 dark:text-slate-400 gap-1.5 mt-0.5">
-                                                        <span>Monthly: £{monthlyAmount.toFixed(2)}</span>
-                                                        <span className="text-slate-300 dark:text-slate-600">•</span>
-                                                        <span>Annual: £{annualAmount.toFixed(2)}</span>
-                                                    </div>
-                                                </div>
-                                            </div>
-
-                                            <div className="flex justify-between items-end mt-1">
-                                                <div className="text-2xl font-bold text-slate-900 dark:text-slate-100">
-                                                    £{actualAmount.toLocaleString('en-GB', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}
-                                                </div>
-                                                <button
-                                                    onClick={() => navigate(`/budgets/edit/${budget.id}`)}
-                                                    className="w-8 h-8 rounded-full bg-[#1DAF61] flex items-center justify-center cursor-pointer hover:bg-[#189653] transition-colors"
-                                                >
-                                                    <Icon name="edit" className="text-white text-sm" />
-                                                </button>
-                                            </div>
-
-                                            <div className="h-2 w-full bg-slate-100 dark:bg-slate-800 rounded-full overflow-hidden mt-1">
-                                                <div
-                                                    className={`h-full rounded-full ${barColor}`}
-                                                    style={{ width: `${percent}%` }}
-                                                />
-                                            </div>
-                                        </div>
-                                    );
                                 }
 
                                 return (


### PR DESCRIPTION
Removes the compact view from the Budgets page and defaults to the detailed view, removing associated toggle controls and state.

---
*PR created automatically by Jules for task [8602732249434033494](https://jules.google.com/task/8602732249434033494) started by @John-Bell*