### PR TITLE
Restrict Projected Interest to Taxable Accounts Only

### DIFF
--- a/src/constants/taxConstants.ts
+++ b/src/constants/taxConstants.ts
@@ -69,6 +69,13 @@ export const ACCOUNT_CATEGORIES: AccountCategory[] = [
   'DC Pension'
 ];
 
+export const TAX_FREE_CATEGORIES: AccountCategory[] = [
+  'Cash ISA',
+  'Shares ISA',
+  'Premium Bonds',
+  'DC Pension'
+];
+
 const DEFAULT_TAX_YEAR = '2025-2026';
 
 export type TaxRulesByYear = Record<string, TaxYearConstants>;

--- a/src/hooks/useHybridForecast.ts
+++ b/src/hooks/useHybridForecast.ts
@@ -1,10 +1,17 @@
 import { useLiveQuery } from 'dexie-react-hooks';
 import { db } from '@/lib/db';
 import { calculateHybridForecast } from '@/utils/forecastUtils';
+import { TAX_FREE_CATEGORIES } from '@/constants/taxConstants';
 
 export function useHybridForecast(taxYearStart: number, taxYearEnd: number) {
     const accounts = useLiveQuery(
-        () => db.accounts.filter(a => a.balance > 0 && a.interestRate > 0).toArray(),
+        () => db.accounts
+            .filter(a =>
+                a.balance > 0 &&
+                a.interestRate > 0 &&
+                (!a.category || !TAX_FREE_CATEGORIES.includes(a.category as any))
+            )
+            .toArray(),
         []
     );
 

--- a/src/hooks/useSimulatorCalculations.ts
+++ b/src/hooks/useSimulatorCalculations.ts
@@ -6,7 +6,7 @@ import { useTaxService } from '@/hooks/useTaxService';
 import type { TaxCalculationInput } from '@/models/TaxCalculationInput';
 import type { TaxCalculationResult } from '@/models/TaxCalculationResult';
 import { calculateHybridForecast } from '@/utils/forecastUtils';
-import { getTaxYearDates } from '@/constants/taxConstants';
+import { getTaxYearDates, TAX_FREE_CATEGORIES } from '@/constants/taxConstants';
 import { calculatePropertyIncomeForTaxYear, calculatePropertyExpensesForTaxYear } from '@/utils/propertyCalculations';
 
 export interface PropertyBreakdown {
@@ -142,18 +142,17 @@ export function useSimulatorCalculations(movableInterestP1Percent?: number, prop
         }
 
         if (dbAccounts) {
-            const taxFreeCategories = ['Cash ISA', 'Shares ISA', 'Premium Bonds'];
-            const taxableAccounts = dbAccounts.filter(acc => !acc.category || !taxFreeCategories.includes(acc.category as string));
+            const taxableAccounts = dbAccounts.filter(acc => !acc.category || !TAX_FREE_CATEGORIES.includes(acc.category as any));
 
             const movableAccounts = taxableAccounts.filter(acc => {
                 const frequency = acc.interestPayoutFrequency || 'monthly';
                 const payoutTs = acc.interestPayoutDate;
-                return acc.category !== 'DC Pension' && frequency !== 'annually' && frequency !== 'at_maturity' && !payoutTs;
+                return frequency !== 'annually' && frequency !== 'at_maturity' && !payoutTs;
             });
             const nonMovableAccounts = taxableAccounts.filter(acc => {
                 const frequency = acc.interestPayoutFrequency || 'monthly';
                 const payoutTs = acc.interestPayoutDate;
-                return acc.category === 'DC Pension' || !(frequency !== 'annually' && frequency !== 'at_maturity' && !payoutTs);
+                return !(frequency !== 'annually' && frequency !== 'at_maturity' && !payoutTs);
             });
 
             // Movable

--- a/src/hooks/useTaxCalculations.ts
+++ b/src/hooks/useTaxCalculations.ts
@@ -6,7 +6,7 @@ import { useTaxService } from '@/hooks/useTaxService';
 import type { TaxCalculationInput } from '@/models/TaxCalculationInput';
 import type { TaxCalculationResult } from '@/models/TaxCalculationResult';
 import { calculateHybridForecast } from '@/utils/forecastUtils';
-import { getTaxYearDates } from '@/constants/taxConstants';
+import { getTaxYearDates, TAX_FREE_CATEGORIES } from '@/constants/taxConstants';
 import { calculatePropertyIncomeForTaxYear, calculatePropertyExpensesForTaxYear } from '@/utils/propertyCalculations';
 
 
@@ -76,8 +76,7 @@ export function useTaxCalculations(): UseTaxCalculationsResult {
         }
 
         if (dbAccounts) {
-            const taxFreeCategories = ['Cash ISA', 'Shares ISA', 'Premium Bonds'];
-            const taxableAccounts = dbAccounts.filter(acc => !acc.category || !taxFreeCategories.includes(acc.category as string));
+            const taxableAccounts = dbAccounts.filter(acc => !acc.category || !TAX_FREE_CATEGORIES.includes(acc.category as any));
 
             const p1Accounts = taxableAccounts.filter(acc => acc.ownerId === 'person1');
             const p2Accounts = taxableAccounts.filter(acc => acc.ownerId === 'person2');

--- a/src/services/accountCalculations.ts
+++ b/src/services/accountCalculations.ts
@@ -1,6 +1,6 @@
 import { type Account, type InterestAccrual } from '@/lib/db';
 import { calculateHybridForecast } from '@/utils/forecastUtils';
-import { getTaxYearDates } from '@/constants/taxConstants';
+import { getTaxYearDates, TAX_FREE_CATEGORIES } from '@/constants/taxConstants';
 
 export function calculateTotalSavings(accounts: Account[]): number {
     return accounts.reduce((sum, acc) => sum + (acc.balance || 0), 0);
@@ -11,9 +11,8 @@ export function calculateNonPensionSavings(accounts: Account[]): number {
 }
 
 export function calculateTaxableSavings(accounts: Account[]): number {
-    const excludedCategories = ['DC Pension', 'Premium Bonds', 'Cash ISA'];
     return accounts.reduce((sum, acc) => {
-        if (acc.category && excludedCategories.includes(acc.category)) {
+        if (acc.category && TAX_FREE_CATEGORIES.includes(acc.category as any)) {
             return sum;
         }
         return sum + (acc.balance || 0);
@@ -21,10 +20,9 @@ export function calculateTaxableSavings(accounts: Account[]): number {
 }
 
 export function calculateTaxableInterest(accounts: Account[], allAccruals: InterestAccrual[] = [], taxYear?: string): number {
-    const excludedCategories = ['DC Pension', 'Premium Bonds', 'Cash ISA', 'Shares ISA'];
     const { startTs, endTs } = getTaxYearDates(taxYear);
 
-    const filteredAccounts = accounts.filter(acc => !acc.category || !excludedCategories.includes(acc.category));
+    const filteredAccounts = accounts.filter(acc => !acc.category || !TAX_FREE_CATEGORIES.includes(acc.category as any));
 
     return calculateHybridForecast(filteredAccounts, allAccruals, startTs, endTs);
 }


### PR DESCRIPTION
This PR ensures that all projected interest displays across the application—specifically on the Simulation page, Income page, and the individual partner tabs on the Accounts page—only reflect interest from taxable accounts.

To achieve this consistently, a new `TAX_FREE_CATEGORIES` constant was introduced in `src/constants/taxConstants.ts`, which includes 'Cash ISA', 'Shares ISA', 'Premium Bonds', and 'DC Pension'. This constant is now used by the following hooks and services to filter out tax-free wrappers from interest projections:
- `useTaxCalculations`: Filters interest for the main Income page breakdown.
- `useSimulatorCalculations`: Filters both movable and non-movable interest for the Simulator.
- `useHybridForecast`: Ensures the `ForecastWidget` on the Accounts page shows taxable interest only.
- `accountCalculations.ts`: Updates `calculateTaxableSavings` and `calculateTaxableInterest` to use the unified exclusion list.

Visual verification was performed using Playwright, confirming that with a mix of taxable and tax-free accounts, only the taxable portion is aggregated into the projected interest totals.

Fixes #200

---
*PR created automatically by Jules for task [7712928488887757479](https://jules.google.com/task/7712928488887757479) started by @John-Bell*