### PR TITLE
Fix hybrid forecast to accurately reflect past actuals for zero-balance accounts

### DIFF
--- a/src/components/accounts/ForecastWidget.tsx
+++ b/src/components/accounts/ForecastWidget.tsx
@@ -1,8 +1,10 @@
 import { useHybridForecast } from '@/hooks/useHybridForecast';
 import { getTaxYearDates } from '@/constants/taxConstants';
+import { useStore } from '@/store/useStore';
 
 export function ForecastWidget() {
-    const { startTs, endTs } = getTaxYearDates();
+    const { taxYear } = useStore();
+    const { startTs, endTs } = getTaxYearDates(taxYear || undefined);
     const { forecastedTotal, isLoading } = useHybridForecast(startTs, endTs);
 
     if (isLoading) {

--- a/src/hooks/useHybridForecast.ts
+++ b/src/hooks/useHybridForecast.ts
@@ -6,11 +6,7 @@ import { TAX_FREE_CATEGORIES } from '@/constants/taxConstants';
 export function useHybridForecast(taxYearStart: number, taxYearEnd: number) {
     const accounts = useLiveQuery(
         () => db.accounts
-            .filter(a =>
-                a.balance > 0 &&
-                a.interestRate > 0 &&
-                (!a.category || !TAX_FREE_CATEGORIES.includes(a.category as any))
-            )
+            .filter(a => !a.category || !TAX_FREE_CATEGORIES.includes(a.category as any))
             .toArray(),
         []
     );


### PR DESCRIPTION
Fixes an issue where the overall projected tax year interest did not match the sum of individual partners' interest. This was caused by filtering out accounts with a zero balance or zero interest rate, which caused any historical interest accrued by those accounts to lose its owner attribution and be omitted from the per-partner breakdown (though the total widget may have calculated differently if querying accruals independently). Removing the zero-balance/rate filters and ensuring the global `taxYear` state is respected resolves the mismatch and provides an accurate, unified projection for the selected year.

---
*PR created automatically by Jules for task [14312163173816577121](https://jules.google.com/task/14312163173816577121) started by @John-Bell*