### PR TITLE
Fix ForecastWidget Date Desync and Standardize Taxable Interest Calculations

### DIFF
--- a/src/components/accounts/ForecastWidget.tsx
+++ b/src/components/accounts/ForecastWidget.tsx
@@ -1,8 +1,11 @@
 import { useHybridForecast } from '@/hooks/useHybridForecast';
-import { getTaxYearDates } from '@/constants/taxConstants';
 
-export function ForecastWidget() {
-    const { startTs, endTs } = getTaxYearDates();
+interface ForecastWidgetProps {
+    startTs: number;
+    endTs: number;
+}
+
+export function ForecastWidget({ startTs, endTs }: ForecastWidgetProps) {
     const { forecastedTotal, isLoading } = useHybridForecast(startTs, endTs);
 
     if (isLoading) {

--- a/src/hooks/useHybridForecast.ts
+++ b/src/hooks/useHybridForecast.ts
@@ -1,15 +1,13 @@
 import { useLiveQuery } from 'dexie-react-hooks';
 import { db } from '@/lib/db';
-import { calculateHybridForecast } from '@/utils/forecastUtils';
-import { TAX_FREE_CATEGORIES } from '@/constants/taxConstants';
+import { calculateProjectedTaxableInterest } from '@/services/accountCalculations';
 
 export function useHybridForecast(taxYearStart: number, taxYearEnd: number) {
     const accounts = useLiveQuery(
         () => db.accounts
             .filter(a =>
                 a.balance > 0 &&
-                a.interestRate > 0 &&
-                (!a.category || !TAX_FREE_CATEGORIES.includes(a.category as any))
+                a.interestRate > 0
             )
             .toArray(),
         []
@@ -24,7 +22,7 @@ export function useHybridForecast(taxYearStart: number, taxYearEnd: number) {
 
     let forecastedTotal = 0;
     if (!isLoading && accounts && accruals) {
-        forecastedTotal = calculateHybridForecast(accounts, accruals, taxYearStart, taxYearEnd);
+        forecastedTotal = calculateProjectedTaxableInterest(accounts, accruals, taxYearStart, taxYearEnd);
     }
 
     return { forecastedTotal, isLoading };

--- a/src/pages/AccountsPage.tsx
+++ b/src/pages/AccountsPage.tsx
@@ -5,7 +5,7 @@ import { useLiveQuery } from 'dexie-react-hooks';
 import { db } from '@/lib/db';
 import { useStore } from '@/store/useStore';
 import { formatRelativeTime } from '@/lib/utils';
-import { calculateTotalSavings, calculateNonPensionSavings, calculateTaxableSavings, calculateTaxableInterest } from '@/services/accountCalculations';
+import { calculateTotalSavings, calculateNonPensionSavings, calculateTaxableSavings, calculateProjectedTaxableInterest } from '@/services/accountCalculations';
 import { calculateProjectedAnnualInterest } from '@/utils/interestCalculations';
 import { getTaxYearDates } from '@/constants/taxConstants';
 import { AppLayout } from '../components/layout/AppLayout';
@@ -125,7 +125,7 @@ export function AccountsPage() {
                 <PortfolioOverview totalSavings={formattedTotalSavings} nonPensionSavings={formattedNonPensionSavings} taxableSavings={formattedTaxableSavings} />
 
                 <div className="my-6">
-                    <ForecastWidget />
+                    <ForecastWidget startTs={startTs} endTs={endTs} />
                 </div>
 
                 <button
@@ -139,7 +139,7 @@ export function AccountsPage() {
                 <div className="flex bg-slate-100 dark:bg-black/20 p-1 rounded-xl mb-4 text-sm font-medium border border-black/5 dark:border-white/5">
                     {['person1', 'person2', 'joint'].map((tab) => {
                         const tabAccounts = rawAccounts.filter(acc => acc.ownerId === tab);
-                        const tabTaxableInterest = calculateTaxableInterest(tabAccounts, allAccruals, taxYear || undefined);
+                        const tabTaxableInterest = calculateProjectedTaxableInterest(tabAccounts, allAccruals, startTs, endTs);
                         const formattedTabTaxableInterest = new Intl.NumberFormat('en-GB', {
                             style: 'currency',
                             currency: 'GBP',

--- a/src/services/accountCalculations.test.ts
+++ b/src/services/accountCalculations.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest';
-import { calculateTotalSavings, calculateBlendedRate, calculateTaxableSavings, calculateTaxableInterest } from './accountCalculations';
+import { calculateTotalSavings, calculateBlendedRate, calculateTaxableSavings, calculateProjectedTaxableInterest } from './accountCalculations';
+import { getTaxYearDates } from '@/constants/taxConstants';
 import { type Account } from '@/lib/db';
 
 describe('accountCalculations', () => {
@@ -161,9 +162,11 @@ describe('calculateTaxableSavings', () => {
     });
 });
 
-describe('calculateTaxableInterest', () => {
+describe('calculateProjectedTaxableInterest', () => {
+    const { startTs, endTs } = getTaxYearDates();
+
     it('returns 0 when accounts is empty', () => {
-        expect(calculateTaxableInterest([])).toBe(0);
+        expect(calculateProjectedTaxableInterest([], [], startTs, endTs)).toBe(0);
     });
 
     it('calculates interest for non-excluded categories', () => {
@@ -174,7 +177,7 @@ describe('calculateTaxableInterest', () => {
         // 1000 * 0.05 = 50
         // 2000 * 0.02 = 40
         // Total = 90
-        expect(calculateTaxableInterest(accounts)).toBeCloseTo(90, 4);
+        expect(calculateProjectedTaxableInterest(accounts, [], startTs, endTs)).toBeCloseTo(90, 4);
     });
 
     it('excludes DC Pension accounts from interest calculation', () => {
@@ -182,7 +185,7 @@ describe('calculateTaxableInterest', () => {
             { id: '1', name: 'Acc 1', balance: 1000, ownerId: 'p1', updatedAt: 0, category: 'Current Account', interestRate: 5 },
             { id: '2', name: 'Acc 2', balance: 5000, ownerId: 'p2', updatedAt: 0, category: 'DC Pension', interestRate: 10 },
         ];
-        expect(calculateTaxableInterest(accounts)).toBeCloseTo(50, 4);
+        expect(calculateProjectedTaxableInterest(accounts, [], startTs, endTs)).toBeCloseTo(50, 4);
     });
 
     it('excludes Premium Bonds accounts from interest calculation', () => {
@@ -190,7 +193,7 @@ describe('calculateTaxableInterest', () => {
             { id: '1', name: 'Acc 1', balance: 1000, ownerId: 'p1', updatedAt: 0, category: 'Current Account', interestRate: 5 },
             { id: '2', name: 'Acc 2', balance: 5000, ownerId: 'p2', updatedAt: 0, category: 'Premium Bonds', interestRate: 10 },
         ];
-        expect(calculateTaxableInterest(accounts)).toBeCloseTo(50, 4);
+        expect(calculateProjectedTaxableInterest(accounts, [], startTs, endTs)).toBeCloseTo(50, 4);
     });
 
     it('excludes Cash ISA accounts from interest calculation', () => {
@@ -198,7 +201,7 @@ describe('calculateTaxableInterest', () => {
             { id: '1', name: 'Acc 1', balance: 1000, ownerId: 'p1', updatedAt: 0, category: 'Current Account', interestRate: 5 },
             { id: '2', name: 'Acc 2', balance: 5000, ownerId: 'p2', updatedAt: 0, category: 'Cash ISA', interestRate: 10 },
         ];
-        expect(calculateTaxableInterest(accounts)).toBeCloseTo(50, 4);
+        expect(calculateProjectedTaxableInterest(accounts, [], startTs, endTs)).toBeCloseTo(50, 4);
     });
 
     it('excludes Shares ISA accounts from interest calculation', () => {
@@ -206,7 +209,7 @@ describe('calculateTaxableInterest', () => {
             { id: '1', name: 'Acc 1', balance: 1000, ownerId: 'p1', updatedAt: 0, category: 'Current Account', interestRate: 5 },
             { id: '2', name: 'Acc 2', balance: 5000, ownerId: 'p2', updatedAt: 0, category: 'Shares ISA', interestRate: 10 },
         ];
-        expect(calculateTaxableInterest(accounts)).toBeCloseTo(50, 4);
+        expect(calculateProjectedTaxableInterest(accounts, [], startTs, endTs)).toBeCloseTo(50, 4);
     });
 
     it('excludes a mix of excluded categories and includes valid ones', () => {
@@ -221,6 +224,6 @@ describe('calculateTaxableInterest', () => {
         // 1000 * 0.05 = 50
         // 3000 * 0.02 = 60
         // Total = 110
-        expect(calculateTaxableInterest(accounts)).toBeCloseTo(110, 4);
+        expect(calculateProjectedTaxableInterest(accounts, [], startTs, endTs)).toBeCloseTo(110, 4);
     });
 });

--- a/src/services/accountCalculations.ts
+++ b/src/services/accountCalculations.ts
@@ -19,9 +19,7 @@ export function calculateTaxableSavings(accounts: Account[]): number {
     }, 0);
 }
 
-export function calculateTaxableInterest(accounts: Account[], allAccruals: InterestAccrual[] = [], taxYear?: string): number {
-    const { startTs, endTs } = getTaxYearDates(taxYear);
-
+export function calculateProjectedTaxableInterest(accounts: Account[], allAccruals: InterestAccrual[] = [], startTs: number, endTs: number): number {
     const filteredAccounts = accounts.filter(acc => !acc.category || !TAX_FREE_CATEGORIES.includes(acc.category as any));
 
     return calculateHybridForecast(filteredAccounts, allAccruals, startTs, endTs);


### PR DESCRIPTION
The `ForecastWidget` was incorrectly displaying default system dates for interest projection because it ignored the global `taxYear` state context. Moreover, there was a calculation desync between the "Tabs" on the Accounts page and the widget itself due to using divergent underlying functions. 

This commit:
1. Plumbs `startTs` and `endTs` into `ForecastWidget` as props so it stays context-aware.
2. Unifies all taxable interest projections under a single pure function `calculateProjectedTaxableInterest`, standardizing the filtering of `TAX_FREE_CATEGORIES` and ensuring accurate math.

---
*PR created automatically by Jules for task [11340926056935347496](https://jules.google.com/task/11340926056935347496) started by @John-Bell*