### PR TITLE
Fix Projected Taxable Interest Logic

### DIFF
--- a/src/services/accountCalculations.test.ts
+++ b/src/services/accountCalculations.test.ts
@@ -165,6 +165,16 @@ describe('calculateTaxableSavings', () => {
 describe('calculateProjectedTaxableInterest', () => {
     const { startTs, endTs } = getTaxYearDates();
 
+    beforeAll(() => {
+        // Mock Date.now to startTs so daysRemaining is exactly (endTs - startTs) / msPerDay, which is ~365 days
+        vi.useFakeTimers();
+        vi.setSystemTime(new Date(startTs));
+    });
+
+    afterAll(() => {
+        vi.useRealTimers();
+    });
+
     it('returns 0 when accounts is empty', () => {
         expect(calculateProjectedTaxableInterest([], [], startTs, endTs)).toBe(0);
     });

--- a/src/services/accountCalculations.ts
+++ b/src/services/accountCalculations.ts
@@ -19,10 +19,45 @@ export function calculateTaxableSavings(accounts: Account[]): number {
     }, 0);
 }
 
-export function calculateProjectedTaxableInterest(accounts: Account[], allAccruals: InterestAccrual[] = [], startTs: number, endTs: number): number {
-    const filteredAccounts = accounts.filter(acc => !acc.category || !TAX_FREE_CATEGORIES.includes(acc.category as any));
+export function calculateProjectedTaxableInterest(
+    accounts: Account[],
+    accruals: InterestAccrual[],
+    startTs: number,
+    endTs: number
+): number {
+    const now = Date.now();
+    let total = 0;
 
-    return calculateHybridForecast(filteredAccounts, allAccruals, startTs, endTs);
+    for (const account of accounts) {
+        if (
+            account.category === 'Cash ISA' ||
+            account.category === 'Shares ISA' ||
+            account.category === 'Premium Bonds' ||
+            account.category === 'DC Pension'
+        ) {
+            continue;
+        }
+
+        const accountAccruals = accruals.filter(a => a.accountId === account.id);
+        const actuals = accountAccruals.reduce((sum, a) => sum + (a.interestAccrued || 0), 0);
+
+        let daysRemaining = 0;
+        if (now > endTs) {
+            daysRemaining = 0;
+        } else if (now < startTs) {
+            daysRemaining = 365;
+        } else {
+            daysRemaining = (endTs - now) / (1000 * 60 * 60 * 24);
+        }
+
+        const balance = account.balance || 0;
+        const rate = account.interestRate || 0;
+        const forecastAmount = balance * (rate / 100) * (daysRemaining / 365);
+
+        total += actuals + forecastAmount;
+    }
+
+    return total;
 }
 
 export function calculateBlendedRate(accounts: Account[], allAccruals: InterestAccrual[] = [], taxYear?: string): number {


### PR DESCRIPTION
Refactors `calculateProjectedTaxableInterest` to specifically implement its own financial year forecast formula `(account.balance) * (account.interestRate / 100) * (daysRemaining / 365)`, replacing the generic hybrid forecast implementation to precisely match requested behavior while retaining purity within the calculations. Updates the related test suite to utilize mocked time for deterministic assertions on day calculations.

---
*PR created automatically by Jules for task [4604745543001856045](https://jules.google.com/task/4604745543001856045) started by @John-Bell*