### PR TITLE
Fix broken build by excluding tests from app compilation and fixing missing imports

### DIFF
--- a/src/services/accountCalculations.test.ts
+++ b/src/services/accountCalculations.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
 import { calculateTotalSavings, calculateBlendedRate, calculateTaxableSavings, calculateProjectedTaxableInterest } from './accountCalculations';
 import { getTaxYearDates } from '@/constants/taxConstants';
 import { type Account } from '@/lib/db';

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -36,5 +36,9 @@
   },
   "include": [
     "src"
+  ],
+  "exclude": [
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx"
   ]
 }


### PR DESCRIPTION
The build was broken because `npm run build` (which runs `tsc -b`) was attempting to compile test files in the `src` directory. Some of these test files had missing imports for Vitest utilities (`vi`, `beforeAll`, etc.), causing TypeScript errors.

I have fixed this by:
1. Excluding `src/**/*.test.ts` and `src/**/*.test.tsx` from `tsconfig.app.json`, which is used for the application build. This is a best practice to keep test-only dependencies and globals out of the main app compilation.
2. Fixing the missing imports in `src/services/accountCalculations.test.ts` to ensure the test suite itself is healthy.

Verified that `npm run build` and `npm run test` both pass successfully.

Fixes #205

---
*PR created automatically by Jules for task [2664929795666063700](https://jules.google.com/task/2664929795666063700) started by @John-Bell*