### PR TITLE
Fix forecast widget data discrepancy

### DIFF
--- a/src/hooks/useHybridForecast.ts
+++ b/src/hooks/useHybridForecast.ts
@@ -3,15 +3,7 @@ import { db } from '@/lib/db';
 import { calculateProjectedTaxableInterest } from '@/services/accountCalculations';
 
 export function useHybridForecast(taxYearStart: number, taxYearEnd: number) {
-    const accounts = useLiveQuery(
-        () => db.accounts
-            .filter(a =>
-                a.balance > 0 &&
-                a.interestRate > 0
-            )
-            .toArray(),
-        []
-    );
+    const accounts = useLiveQuery(() => db.accounts.toArray(), []);
 
     const accruals = useLiveQuery(
         () => db.interestAccruals.where('date').between(taxYearStart, taxYearEnd, true, true).toArray(),

--- a/src/pages/AccountsPage.tsx
+++ b/src/pages/AccountsPage.tsx
@@ -24,8 +24,16 @@ export function AccountsPage() {
 
     const [sortBy, setSortBy] = useState<'rate' | 'name'>('rate');
 
+    const { startTs, endTs } = getTaxYearDates(taxYear || undefined);
+
     const rawAccounts = useLiveQuery(() => db.accounts.toArray()) || [];
-    const allAccruals = useLiveQuery(() => db.interestAccruals.toArray()) || [];
+    const allAccruals = useLiveQuery(
+        () => db.interestAccruals
+            .where('date')
+            .between(startTs, endTs, true, true)
+            .toArray(),
+        [startTs, endTs]
+    ) || [];
 
     const sortedRawAccounts = [...rawAccounts].sort((a, b) => {
         if (sortBy === 'rate') {
@@ -34,8 +42,6 @@ export function AccountsPage() {
             return (a.name || '').localeCompare(b.name || '');
         }
     });
-
-    const { startTs, endTs } = getTaxYearDates(taxYear || undefined);
 
     const mappedAccounts = sortedRawAccounts.map(acc => {
         let ownerTagColor: 'blue' | 'pink' | 'purple' = 'purple';


### PR DESCRIPTION
Fixes massive discrepancy in calculations between `<ForecastWidget />` and the Person Tabs on `AccountsPage`. Aligns data-fetching by bounding interest accruals strictly to the active tax year and preserving all accounts in the dataset prior to calculations.

---
*PR created automatically by Jules for task [13797846628686246891](https://jules.google.com/task/13797846628686246891) started by @John-Bell*