### PR TITLE
Default alphanumeric sort on accounts page

### DIFF
--- a/src/pages/AccountsPage.tsx
+++ b/src/pages/AccountsPage.tsx
@@ -22,7 +22,7 @@ export function AccountsPage() {
     const p1Name = profile?.partner1Name || 'Partner 1';
     const p2Name = profile?.partner2Name || 'Partner 2';
 
-    const [sortBy, setSortBy] = useState<'rate' | 'name'>('rate');
+    const [sortBy, setSortBy] = useState<'rate' | 'name'>('name');
 
     const { startTs, endTs } = getTaxYearDates(taxYear || undefined);
 

--- a/tests/account-sort.spec.ts
+++ b/tests/account-sort.spec.ts
@@ -1,0 +1,87 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('Account Sorting', () => {
+    test.beforeEach(async ({ page }) => {
+        await page.goto('/incometrack/');
+        await page.waitForLoadState('networkidle');
+
+        const isSetup = await page.url().includes('/setup');
+        if (isSetup) {
+            await page.getByPlaceholder('e.g. Alex').first().fill('Alex');
+            await page.getByPlaceholder('e.g. Sam').fill('Sam');
+            await page.getByRole('button', { name: /Get Started/ }).click();
+            await page.waitForURL('**/incometrack/', { timeout: 15000 });
+        }
+
+        await page.evaluate(async () => {
+            const db = (window as any).__DEXIE_DB__;
+            if (!db) return;
+
+            // Clear existing data
+            await db.accounts.clear();
+            await db.budgets.clear();
+            await db.transactions.clear();
+
+            await db.accounts.bulkAdd([
+                {
+                    id: 'acc_b',
+                    name: 'Bank B',
+                    balance: 1000,
+                    interestRate: 5.0,
+                    ownerId: 'joint',
+                    category: 'Savings',
+                    updatedAt: Date.now()
+                },
+                {
+                    id: 'acc_a',
+                    name: 'Bank A',
+                    balance: 500,
+                    interestRate: 1.0,
+                    ownerId: 'joint',
+                    category: 'Savings',
+                    updatedAt: Date.now()
+                },
+                {
+                    id: 'acc_c',
+                    name: 'Bank C',
+                    balance: 2000,
+                    interestRate: 3.0,
+                    ownerId: 'joint',
+                    category: 'Savings',
+                    updatedAt: Date.now()
+                }
+            ]);
+        });
+
+        await page.goto('/incometrack/accounts');
+        await page.waitForLoadState('networkidle');
+    });
+
+    test('should sort accounts by name by default', async ({ page }) => {
+        // Default sort should be by name: Bank A, Bank B, Bank C
+
+        // Wait for accounts to be visible and ensure we are on the accounts page
+        await expect(page.locator('h3').filter({ hasText: 'Bank A' })).toBeVisible({ timeout: 15000 });
+
+        // Filter h3 to only include our bank names to avoid other h3s like "Projected Tax Year Interest"
+        const names = await page.locator('h3').allTextContents();
+        const bankNames = names.filter(n => n.startsWith('Bank '));
+        expect(bankNames).toEqual(['Bank A', 'Bank B', 'Bank C']);
+    });
+
+    test('should allow switching to sort by rate', async ({ page }) => {
+        await expect(page.locator('h3').filter({ hasText: 'Bank A' })).toBeVisible({ timeout: 15000 });
+
+        const sortButton = page.getByRole('button', { name: /Sort by/i });
+        await sortButton.click();
+
+        // After clicking, it should sort by rate (ascending): Bank A (1.0%), Bank C (3.0%), Bank B (5.0%)
+
+        // We expect the order to change. Let's wait for the expected order.
+        await expect(async () => {
+            const names = await page.locator('h3').allTextContents();
+            const bankNames = names.filter(n => n.startsWith('Bank '));
+            expect(bankNames).toEqual(['Bank A', 'Bank C', 'Bank B']);
+        }).toPass();
+    });
+});


### PR DESCRIPTION
This change updates the default sort order of accounts on the Accounts page to be alphanumeric (by name). Previously, it defaulted to sorting by interest rate. A new Playwright test suite has been added to ensure the default remains correct and that users can still manually switch to sorting by rate. All existing tests pass.

Fixes #214

---
*PR created automatically by Jules for task [18021858654237471829](https://jules.google.com/task/18021858654237471829) started by @John-Bell*