### PR TITLE
Standardize interest forecasting on account cards

### DIFF
--- a/src/components/accounts/AccountCard.tsx
+++ b/src/components/accounts/AccountCard.tsx
@@ -16,6 +16,7 @@ interface AccountCardProps extends HTMLAttributes<HTMLDivElement> {
     ownerTagColor: 'purple' | 'blue' | 'pink';
     balance: string;
     projectedInterest?: string;
+    isTaxable?: boolean;
     rate?: string;
     interestPayoutFrequency?: string;
     interestPayoutDate?: number;
@@ -59,6 +60,7 @@ export function AccountCard({
     ownerTagColor,
     balance,
     projectedInterest,
+    isTaxable,
     rate,
     interestPayoutFrequency,
     interestPayoutDate,
@@ -144,7 +146,7 @@ export function AccountCard({
                     <span className="text-2xl font-extrabold text-slate-900 dark:text-white tracking-tight">{balance}</span>
                     {projectedInterest && (
                         <span className="text-xs text-slate-500 dark:text-[#9db9b0] mt-0.5">
-                            + {projectedInterest}
+                            + {projectedInterest} {isTaxable === false ? 'interest' : 'taxable interest'} this year
                         </span>
                     )}
                 </div>

--- a/src/components/accounts/AccountCard.tsx
+++ b/src/components/accounts/AccountCard.tsx
@@ -144,7 +144,7 @@ export function AccountCard({
                     <span className="text-2xl font-extrabold text-slate-900 dark:text-white tracking-tight">{balance}</span>
                     {projectedInterest && (
                         <span className="text-xs text-slate-500 dark:text-[#9db9b0] mt-0.5">
-                            + {projectedInterest} interest this year
+                            + {projectedInterest}
                         </span>
                     )}
                 </div>

--- a/src/pages/AccountsPage.tsx
+++ b/src/pages/AccountsPage.tsx
@@ -5,9 +5,8 @@ import { useLiveQuery } from 'dexie-react-hooks';
 import { db } from '@/lib/db';
 import { useStore } from '@/store/useStore';
 import { formatRelativeTime } from '@/lib/utils';
-import { calculateTotalSavings, calculateNonPensionSavings, calculateTaxableSavings, calculateProjectedTaxableInterest } from '@/services/accountCalculations';
-import { calculateProjectedAnnualInterest } from '@/utils/interestCalculations';
-import { getTaxYearDates } from '@/constants/taxConstants';
+import { calculateTotalSavings, calculateNonPensionSavings, calculateTaxableSavings, calculateProjectedTaxableInterest, calculateProjectedInterestForAccount } from '@/services/accountCalculations';
+import { getTaxYearDates, TAX_FREE_CATEGORIES } from '@/constants/taxConstants';
 import { AppLayout } from '../components/layout/AppLayout';
 import { Header } from '../components/layout/Header';
 import { Icon } from '../components/ui/Icon';
@@ -58,9 +57,11 @@ export function AccountsPage() {
         else if (accountIcon === 'B') iconColor = 'blue';
         else if (accountIcon === 'L') iconColor = 'green';
 
-        const accountAccruals = allAccruals.filter(a => a.accountId === acc.id);
-        const projectedInterestValue = calculateProjectedAnnualInterest(acc, accountAccruals, startTs, endTs);
+        const projectedInterestValue = calculateProjectedInterestForAccount(acc, allAccruals, startTs, endTs);
         const projectedInterest = new Intl.NumberFormat('en-GB', { style: 'currency', currency: 'GBP', minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(projectedInterestValue);
+
+        const isTaxFree = acc.category && TAX_FREE_CATEGORIES.includes(acc.category as any);
+        const interestLabel = isTaxFree ? 'interest this year' : 'taxable interest this year';
 
         return {
             id: acc.id,
@@ -74,7 +75,7 @@ export function AccountsPage() {
             ownerTag: acc.ownerId === 'joint' ? 'Joint' : (acc.ownerId === 'person1' ? p1Name : p2Name),
             ownerTagColor,
             balance: new Intl.NumberFormat('en-GB', { style: 'currency', currency: 'GBP', minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(acc.balance),
-            projectedInterest: projectedInterestValue > 0 ? projectedInterest : undefined,
+            projectedInterest: projectedInterestValue > 0 ? `${projectedInterest} ${interestLabel}` : undefined,
             rate: acc.interestRate === 0 ? undefined : acc.interestRate.toFixed(2) + '%',
             interestPayoutFrequency: acc.interestPayoutFrequency,
             interestPayoutDate: acc.interestPayoutDate,

--- a/src/pages/AccountsPage.tsx
+++ b/src/pages/AccountsPage.tsx
@@ -61,7 +61,6 @@ export function AccountsPage() {
         const projectedInterest = new Intl.NumberFormat('en-GB', { style: 'currency', currency: 'GBP', minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(projectedInterestValue);
 
         const isTaxFree = acc.category && TAX_FREE_CATEGORIES.includes(acc.category as any);
-        const interestLabel = isTaxFree ? 'interest this year' : 'taxable interest this year';
 
         return {
             id: acc.id,
@@ -75,7 +74,8 @@ export function AccountsPage() {
             ownerTag: acc.ownerId === 'joint' ? 'Joint' : (acc.ownerId === 'person1' ? p1Name : p2Name),
             ownerTagColor,
             balance: new Intl.NumberFormat('en-GB', { style: 'currency', currency: 'GBP', minimumFractionDigits: 2, maximumFractionDigits: 2 }).format(acc.balance),
-            projectedInterest: projectedInterestValue > 0 ? `${projectedInterest} ${interestLabel}` : undefined,
+            projectedInterest: projectedInterestValue > 0 ? projectedInterest : undefined,
+            isTaxable: !isTaxFree,
             rate: acc.interestRate === 0 ? undefined : acc.interestRate.toFixed(2) + '%',
             interestPayoutFrequency: acc.interestPayoutFrequency,
             interestPayoutDate: acc.interestPayoutDate,

--- a/src/services/accountCalculations.ts
+++ b/src/services/accountCalculations.ts
@@ -1,5 +1,5 @@
 import { type Account, type InterestAccrual } from '@/lib/db';
-import { calculateHybridForecast } from '@/utils/forecastUtils';
+import { calculateHybridForecast, calculateHybridForecastForAccount } from '@/utils/forecastUtils';
 import { getTaxYearDates, TAX_FREE_CATEGORIES } from '@/constants/taxConstants';
 
 export function calculateTotalSavings(accounts: Account[]): number {
@@ -19,45 +19,39 @@ export function calculateTaxableSavings(accounts: Account[]): number {
     }, 0);
 }
 
+export function calculateProjectedInterestForAccount(
+    account: Account,
+    accruals: InterestAccrual[],
+    startTs: number,
+    endTs: number
+): number {
+    const accountAccruals = accruals.filter(
+        a => a.accountId === account.id && a.date >= startTs && a.date <= endTs
+    );
+    return calculateHybridForecastForAccount(account, accountAccruals, startTs, endTs);
+}
+
+export function calculateProjectedTaxableInterestForAccount(
+    account: Account,
+    accruals: InterestAccrual[],
+    startTs: number,
+    endTs: number
+): number {
+    if (account.category && TAX_FREE_CATEGORIES.includes(account.category as any)) {
+        return 0;
+    }
+    return calculateProjectedInterestForAccount(account, accruals, startTs, endTs);
+}
+
 export function calculateProjectedTaxableInterest(
     accounts: Account[],
     accruals: InterestAccrual[],
     startTs: number,
     endTs: number
 ): number {
-    const now = Date.now();
-    let total = 0;
-
-    for (const account of accounts) {
-        if (
-            account.category === 'Cash ISA' ||
-            account.category === 'Shares ISA' ||
-            account.category === 'Premium Bonds' ||
-            account.category === 'DC Pension'
-        ) {
-            continue;
-        }
-
-        const accountAccruals = accruals.filter(a => a.accountId === account.id);
-        const actuals = accountAccruals.reduce((sum, a) => sum + (a.interestAccrued || 0), 0);
-
-        let daysRemaining = 0;
-        if (now > endTs) {
-            daysRemaining = 0;
-        } else if (now < startTs) {
-            daysRemaining = 365;
-        } else {
-            daysRemaining = (endTs - now) / (1000 * 60 * 60 * 24);
-        }
-
-        const balance = account.balance || 0;
-        const rate = account.interestRate || 0;
-        const forecastAmount = balance * (rate / 100) * (daysRemaining / 365);
-
-        total += actuals + forecastAmount;
-    }
-
-    return total;
+    return accounts.reduce((total, account) => {
+        return total + calculateProjectedTaxableInterestForAccount(account, accruals, startTs, endTs);
+    }, 0);
 }
 
 export function calculateBlendedRate(accounts: Account[], allAccruals: InterestAccrual[] = [], taxYear?: string): number {

--- a/src/utils/forecastUtils.ts
+++ b/src/utils/forecastUtils.ts
@@ -1,5 +1,60 @@
 import type { Account, InterestAccrual } from '@/lib/db';
 
+export function calculateHybridForecastForAccount(
+    account: Account,
+    accountAccruals: InterestAccrual[],
+    taxYearStart: number,
+    taxYearEnd: number
+): number {
+    // Step 2: "YTD Actuals"
+    const ytdActuals = accountAccruals.reduce(
+        (sum, accrual) => sum + (accrual.interestAccrued || 0),
+        0
+    );
+
+    // Step 3: "Projection Start Date"
+    let maxAccrualDate = taxYearStart;
+    for (const accrual of accountAccruals) {
+        if (accrual.date > maxAccrualDate) {
+            maxAccrualDate = accrual.date;
+        }
+    }
+    const projectionStartDate = maxAccrualDate;
+
+    // Step 4: "Projection End Date"
+    let projectionEndDate = taxYearEnd;
+    if (
+        account.interestPayoutFrequency === 'at_maturity' &&
+        account.interestPayoutDate
+    ) {
+        if (account.interestPayoutDate <= taxYearEnd) {
+            projectionEndDate = account.interestPayoutDate;
+        } else {
+            projectionEndDate = projectionStartDate;
+        }
+    }
+
+    // Step 5: "Future Projection"
+    let futureProjection = 0;
+    if (projectionStartDate < projectionEndDate) {
+        const daysRemaining = (projectionEndDate - projectionStartDate) / 86400000;
+        const rate = (account.interestRate || 0) / 100;
+        const balance = account.balance || 0;
+        const isCompound = account.isCompound === undefined ? true : account.isCompound;
+
+        if (isCompound) {
+            // AER daily extraction formula
+            futureProjection = balance * (Math.pow(1 + rate, daysRemaining / 365) - 1);
+        } else {
+            // Simple Interest formula
+            futureProjection = balance * rate * (daysRemaining / 365);
+        }
+    }
+
+    // Step 6: Account Total
+    return ytdActuals + futureProjection;
+}
+
 export function calculateHybridForecast(
     accounts: Account[],
     accruals: InterestAccrual[],
@@ -17,53 +72,7 @@ export function calculateHybridForecast(
                 accrual.date <= taxYearEnd
         );
 
-        // Step 2: "YTD Actuals"
-        const ytdActuals = accountAccruals.reduce(
-            (sum, accrual) => sum + (accrual.interestAccrued || 0),
-            0
-        );
-
-        // Step 3: "Projection Start Date"
-        let maxAccrualDate = taxYearStart;
-        for (const accrual of accountAccruals) {
-            if (accrual.date > maxAccrualDate) {
-                maxAccrualDate = accrual.date;
-            }
-        }
-        const projectionStartDate = maxAccrualDate;
-
-        // Step 4: "Projection End Date"
-        let projectionEndDate = taxYearEnd;
-        if (
-            account.interestPayoutFrequency === 'at_maturity' &&
-            account.interestPayoutDate
-        ) {
-            if (account.interestPayoutDate <= taxYearEnd) {
-                projectionEndDate = account.interestPayoutDate;
-            } else {
-                projectionEndDate = projectionStartDate;
-            }
-        }
-
-        // Step 5: "Future Projection"
-        let futureProjection = 0;
-        if (projectionStartDate < projectionEndDate) {
-            const daysRemaining = (projectionEndDate - projectionStartDate) / 86400000;
-            const rate = (account.interestRate || 0) / 100;
-            const balance = account.balance || 0;
-            const isCompound = account.isCompound === undefined ? true : account.isCompound;
-
-            if (isCompound) {
-                // AER daily extraction formula
-                futureProjection = balance * (Math.pow(1 + rate, daysRemaining / 365) - 1);
-            } else {
-                // Simple Interest formula
-                futureProjection = balance * rate * (daysRemaining / 365);
-            }
-        }
-
-        // Step 6: Account Total
-        grandTotal += ytdActuals + futureProjection;
+        grandTotal += calculateHybridForecastForAccount(account, accountAccruals, taxYearStart, taxYearEnd);
     }
 
     return grandTotal;


### PR DESCRIPTION
This change replaces the manual-only interest display on account cards with a hybrid forecast (actuals + projected AER/Simple interest), ensuring consistency with the overall tax year interest projection. It also adds dynamic labels to distinguish between taxable and tax-free interest.

Fixes #218

---
*PR created automatically by Jules for task [10839722801677571404](https://jules.google.com/task/10839722801677571404) started by @John-Bell*