### PR TITLE
Fix calculation of terminal interest for bonds maturing in the current tax year

### DIFF
--- a/src/utils/forecastUtils.test.ts
+++ b/src/utils/forecastUtils.test.ts
@@ -143,4 +143,35 @@ describe('calculateHybridForecast', () => {
 
         expect(result).toBeCloseTo(expected, 2);
     });
+
+    it('Scenario 7: Bond Matures in the Current Tax Year (Full Lump Sum Realized)', () => {
+        // Scenario 1: Bond Matures in the Current Tax Year (Full Lump Sum Realized)
+        //  Account Setup:
+        //  Category: Fixed Term Savings
+        //  Current Balance: £11,000
+        //  Interest Rate: 4.11% (Compounding Annually)
+        //  Payout Frequency: At Maturity
+        //  Bond Term: 2 Years
+        //  Maturity Date: August 19, 2026
+        //  Target Tax Year Evaluation: 2026–2027 (Current Year)
+
+        const testTaxYearStart = new Date('2026-04-06T00:00:00Z').getTime();
+        const testTaxYearEnd = new Date('2027-04-05T23:59:59Z').getTime();
+        const maturityDate = new Date('2026-08-19T00:00:00Z').getTime();
+
+        const bondAccount = createMockAccount({
+            category: 'Fixed Term Savings',
+            balance: 11000,
+            interestRate: 4.11,
+            isCompound: true,
+            interestPayoutFrequency: 'at_maturity',
+            bondTermYears: 2,
+            interestPayoutDate: maturityDate,
+        });
+
+        const result = calculateHybridForecast([bondAccount], [], testTaxYearStart, testTaxYearEnd);
+
+        // Expected Total Interest for This Year: £922.78
+        expect(result).toBeCloseTo(922.78, 2);
+    });
 });

--- a/src/utils/forecastUtils.ts
+++ b/src/utils/forecastUtils.ts
@@ -42,12 +42,28 @@ export function calculateHybridForecastForAccount(
         const balance = account.balance || 0;
         const isCompound = account.isCompound === undefined ? true : account.isCompound;
 
-        if (isCompound) {
-            // AER daily extraction formula
-            futureProjection = balance * (Math.pow(1 + rate, daysRemaining / 365) - 1);
+        if (
+            account.interestPayoutFrequency === 'at_maturity' &&
+            account.interestPayoutDate &&
+            account.interestPayoutDate <= taxYearEnd &&
+            account.interestPayoutDate >= taxYearStart &&
+            account.bondTermYears &&
+            account.bondTermYears > 0
+        ) {
+            // Full Lump Sum Realized
+            if (isCompound) {
+                futureProjection = balance * (Math.pow(1 + rate, account.bondTermYears) - 1);
+            } else {
+                futureProjection = balance * rate * account.bondTermYears;
+            }
         } else {
-            // Simple Interest formula
-            futureProjection = balance * rate * (daysRemaining / 365);
+            if (isCompound) {
+                // AER daily extraction formula
+                futureProjection = balance * (Math.pow(1 + rate, daysRemaining / 365) - 1);
+            } else {
+                // Simple Interest formula
+                futureProjection = balance * rate * (daysRemaining / 365);
+            }
         }
     }
 


### PR DESCRIPTION
Modified `calculateHybridForecastForAccount` to evaluate when an account explicitly matures in the given tax year (`at_maturity`, with an `interestPayoutDate` inside bounds, and `bondTermYears` defined). In this specific scenario, it now applies the full lump sum interest calculation using `bondTermYears` as the exponent. Also added an automated unit test `Scenario 7` verifying this fix using Vitest.

---
*PR created automatically by Jules for task [8144326826555123675](https://jules.google.com/task/8144326826555123675) started by @John-Bell*