### PR TITLE
Filter incomes by start and end dates

### DIFF
--- a/src/hooks/useSimulatorCalculations.ts
+++ b/src/hooks/useSimulatorCalculations.ts
@@ -8,6 +8,7 @@ import type { TaxCalculationResult } from '@/models/TaxCalculationResult';
 import { calculateProjectedTaxableInterest } from '@/services/accountCalculations';
 import { getTaxYearDates, TAX_FREE_CATEGORIES } from '@/constants/taxConstants';
 import { calculatePropertyIncomeForTaxYear, calculatePropertyExpensesForTaxYear } from '@/utils/propertyCalculations';
+import { isIncomeValidInTaxYear } from '@/utils/incomeCalculations';
 
 export interface PropertyBreakdown {
     propertyId: string;
@@ -58,14 +59,16 @@ export function useSimulatorCalculations(movableInterestP1Percent?: number, prop
         let p2MovableInterest = 0;
 
         if (dbIncomes) {
-            dbIncomes.forEach(inc => {
-                const amount = inc.frequency === 'monthly' ? inc.amount * 12 : inc.amount;
-                const target = inc.ownerId === 'person1' ? p1Incomes : p2Incomes;
+            dbIncomes
+                .filter(inc => isIncomeValidInTaxYear(inc, startTs, endTs))
+                .forEach(inc => {
+                    const amount = inc.frequency === 'monthly' ? inc.amount * 12 : inc.amount;
+                    const target = inc.ownerId === 'person1' ? p1Incomes : p2Incomes;
 
-                if (inc.type === 'employment') target.employment += amount;
-                else if (inc.type === 'pension') target.pension += amount;
-                else if (inc.type === 'dividends') target.dividends += amount;
-            });
+                    if (inc.type === 'employment') target.employment += amount;
+                    else if (inc.type === 'pension') target.pension += amount;
+                    else if (inc.type === 'dividends') target.dividends += amount;
+                });
         }
 
         const propertyBreakdowns: PropertyBreakdown[] = [];

--- a/src/hooks/useTaxCalculations.ts
+++ b/src/hooks/useTaxCalculations.ts
@@ -8,6 +8,7 @@ import type { TaxCalculationResult } from '@/models/TaxCalculationResult';
 import { calculateProjectedTaxableInterest } from '@/services/accountCalculations';
 import { getTaxYearDates, TAX_FREE_CATEGORIES } from '@/constants/taxConstants';
 import { calculatePropertyIncomeForTaxYear, calculatePropertyExpensesForTaxYear } from '@/utils/propertyCalculations';
+import { isIncomeValidInTaxYear } from '@/utils/incomeCalculations';
 
 
 export interface UseTaxCalculationsResult {
@@ -43,14 +44,16 @@ export function useTaxCalculations(): UseTaxCalculationsResult {
         const p2Incomes = { employment: 0, pension: 0, propertyIncome: 0, propertyExpense: 0, dividends: 0, interest: 0 };
 
         if (dbIncomes) {
-            dbIncomes.forEach(inc => {
-                const amount = inc.frequency === 'monthly' ? inc.amount * 12 : inc.amount;
-                const target = inc.ownerId === 'person1' ? p1Incomes : p2Incomes;
+            dbIncomes
+                .filter(inc => isIncomeValidInTaxYear(inc, startTs, endTs))
+                .forEach(inc => {
+                    const amount = inc.frequency === 'monthly' ? inc.amount * 12 : inc.amount;
+                    const target = inc.ownerId === 'person1' ? p1Incomes : p2Incomes;
 
-                if (inc.type === 'employment') target.employment += amount;
-                else if (inc.type === 'pension') target.pension += amount;
-                else if (inc.type === 'dividends') target.dividends += amount;
-            });
+                    if (inc.type === 'employment') target.employment += amount;
+                    else if (inc.type === 'pension') target.pension += amount;
+                    else if (inc.type === 'dividends') target.dividends += amount;
+                });
         }
 
         if (dbProperties && dbPropertyIncomes && dbPropertyOwnerships) {

--- a/src/utils/incomeCalculations.test.ts
+++ b/src/utils/incomeCalculations.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'vitest';
+import { isIncomeValidInTaxYear } from './incomeCalculations';
+import type { Income } from '@/lib/db';
+
+describe('isIncomeValidInTaxYear', () => {
+    // 2024-2025 tax year: 2024-04-06 to 2025-04-05
+    const taxYearStart = new Date(2024, 3, 6).getTime();
+    const taxYearEnd = new Date(2025, 3, 5, 23, 59, 59, 999).getTime();
+
+    const baseIncome: Income = {
+        id: 'test-id',
+        ownerId: 'person1',
+        name: 'Test Income',
+        amount: 1000,
+        frequency: 'monthly',
+        type: 'employment',
+        taxCategory: 'Earned'
+    };
+
+    it('returns true for income with no start or end date', () => {
+        expect(isIncomeValidInTaxYear(baseIncome, taxYearStart, taxYearEnd)).toBe(true);
+    });
+
+    it('returns true for income starting before and ending after tax year', () => {
+        const income = {
+            ...baseIncome,
+            startDate: new Date(2023, 0, 1).getTime(),
+            endDate: new Date(2026, 0, 1).getTime()
+        };
+        expect(isIncomeValidInTaxYear(income, taxYearStart, taxYearEnd)).toBe(true);
+    });
+
+    it('returns true for income starting mid-year with no end date', () => {
+        const income = {
+            ...baseIncome,
+            startDate: new Date(2024, 6, 1).getTime()
+        };
+        expect(isIncomeValidInTaxYear(income, taxYearStart, taxYearEnd)).toBe(true);
+    });
+
+    it('returns true for income ending mid-year with no start date', () => {
+        const income = {
+            ...baseIncome,
+            endDate: new Date(2024, 6, 1).getTime()
+        };
+        expect(isIncomeValidInTaxYear(income, taxYearStart, taxYearEnd)).toBe(true);
+    });
+
+    it('returns true for income starting and ending within the tax year', () => {
+        const income = {
+            ...baseIncome,
+            startDate: new Date(2024, 4, 1).getTime(),
+            endDate: new Date(2024, 8, 1).getTime()
+        };
+        expect(isIncomeValidInTaxYear(income, taxYearStart, taxYearEnd)).toBe(true);
+    });
+
+    it('returns false for income ending before the tax year starts', () => {
+        const income = {
+            ...baseIncome,
+            endDate: taxYearStart - 1
+        };
+        expect(isIncomeValidInTaxYear(income, taxYearStart, taxYearEnd)).toBe(false);
+    });
+
+    it('returns false for income starting after the tax year ends', () => {
+        const income = {
+            ...baseIncome,
+            startDate: taxYearEnd + 1
+        };
+        expect(isIncomeValidInTaxYear(income, taxYearStart, taxYearEnd)).toBe(false);
+    });
+
+    it('returns true for income starting exactly on the last day of the tax year', () => {
+        const income = {
+            ...baseIncome,
+            startDate: taxYearEnd
+        };
+        expect(isIncomeValidInTaxYear(income, taxYearStart, taxYearEnd)).toBe(true);
+    });
+
+    it('returns true for income ending exactly on the first day of the tax year', () => {
+        const income = {
+            ...baseIncome,
+            endDate: taxYearStart
+        };
+        expect(isIncomeValidInTaxYear(income, taxYearStart, taxYearEnd)).toBe(true);
+    });
+});

--- a/src/utils/incomeCalculations.ts
+++ b/src/utils/incomeCalculations.ts
@@ -1,0 +1,25 @@
+import type { Income } from '@/lib/db';
+
+/**
+ * Checks if an income record is valid (overlaps) during a given tax year.
+ *
+ * If no start date is set then it means it has started before the current tax year.
+ * If no end date is set then it means the income has no current end date.
+ *
+ * @param income The income record to check.
+ * @param taxYearStartTs Start timestamp of the tax year (inclusive).
+ * @param taxYearEndTs End timestamp of the tax year (inclusive).
+ * @returns True if the income is valid during the tax year.
+ */
+export function isIncomeValidInTaxYear(
+    income: Income,
+    taxYearStartTs: number,
+    taxYearEndTs: number
+): boolean {
+    const incomeStart = income.startDate ?? -Infinity;
+    const incomeEnd = income.endDate ?? Infinity;
+
+    // Overlap logic:
+    // (Income starts before or at the end of the tax year) AND (Income ends after or at the start of the tax year)
+    return incomeStart <= taxYearEndTs && incomeEnd >= taxYearStartTs;
+}


### PR DESCRIPTION
This change implements filtering of income items in the tax calculation hooks based on their optional start and end dates. Income items are now only included in the totals if their active period overlaps with the selected tax year. This ensures that historical or future income streams do not incorrectly affect the current tax year's projections.

Fixes #225

---
*PR created automatically by Jules for task [8437185706992673417](https://jules.google.com/task/8437185706992673417) started by @John-Bell*