### PR TITLE
Add Partner Date of Birth Fields to Profile

### DIFF
--- a/src/lib/db.test.ts
+++ b/src/lib/db.test.ts
@@ -45,7 +45,9 @@ describe('Database Schema', () => {
             id: 'default',
             name: 'Smith Family',
             partner1Name: 'John',
+            partner1Dob: new Date('1980-01-01').getTime(),
             partner2Name: 'Jane',
+            partner2Dob: new Date('1982-05-15').getTime(),
             createdAt: Date.now()
         };
 
@@ -54,6 +56,8 @@ describe('Database Schema', () => {
 
         expect(savedProfile).toEqual(profile);
         expect(savedProfile?.partner1Name).toBe('John');
+        expect(savedProfile?.partner1Dob).toBe(new Date('1980-01-01').getTime());
+        expect(savedProfile?.partner2Dob).toBe(new Date('1982-05-15').getTime());
     });
 
     it('should support new Income fields', async () => {

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -14,6 +14,8 @@ export interface Profile {
     name: string;
     partner1Name?: string;
     partner2Name?: string;
+    partner1Dob?: number;
+    partner2Dob?: number;
     createdAt: number;
     updatedAt?: number;
 }
@@ -454,6 +456,26 @@ db.version(12).stores({
     deletedRows: '&id, tableName, deletedAt'
 });
 
+db.version(15).stores({
+    profile: '&id',
+    accounts: '&id, ownerId, name, category, importId, updatedAt',
+    incomes: '&id, ownerId, name, frequency, type, taxCategory, updatedAt',
+    scenarios: '&id, name, updatedAt',
+    settings: '&id',
+    monthlyArchives: '&id, month, year, updatedAt',
+    notifications: '&id, date, read, updatedAt',
+    taxRules: '&id, updatedAt',
+    budgets: '&id, accountId, name, importId, updatedAt',
+    transactions: '&id, date, type, budgetId, accountId, importId, updatedAt',
+    paymentMappings: '&id, paymentName, *budgetIds, updatedAt',
+    interestAccruals: '&id, accountId, date, updatedAt',
+    properties: '&id, name, updatedAt',
+    propertyExpenses: '&id, propertyId, date, updatedAt',
+    propertyIncomes: '&id, propertyId, date, updatedAt',
+    propertyOwnership: '&id, propertyId, startDate, updatedAt',
+    deletedRows: '&id, tableName, deletedAt'
+});
+
 export const getSanitizedDbData = async (): Promise<Record<string, any[]>> => {
     const rawData = {
         profile: await db.profile.toArray(),
@@ -477,6 +499,14 @@ export const getSanitizedDbData = async (): Promise<Record<string, any[]>> => {
 
     // Sanitize common numeric fields that might have accidentally been saved as strings,
     // which breaks strictly-typed Swift Decodable models in the iOS app.
+    if (rawData.profile) {
+        rawData.profile = rawData.profile.map(p => ({
+            ...p,
+            partner1Dob: p.partner1Dob !== undefined ? Number(p.partner1Dob) : undefined,
+            partner2Dob: p.partner2Dob !== undefined ? Number(p.partner2Dob) : undefined,
+        }));
+    }
+
     if (rawData.transactions) {
         rawData.transactions = rawData.transactions.map(t => ({
             ...t,

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -7,6 +7,7 @@ import { AppLayout } from '../components/layout/AppLayout';
 import { Header } from '../components/layout/Header';
 import { Icon } from '../components/ui/Icon';
 import { MainHeaderActions } from '../components/layout/MainHeaderActions';
+import { DateInput } from '@/components/ui/DateInput';
 
 export function SettingsPage() {
     const navigate = useNavigate();
@@ -14,17 +15,33 @@ export function SettingsPage() {
 
     const settings = useLiveQuery(() => db.settings.toArray());
     const taxRules = useLiveQuery(() => db.taxRules.toArray());
+    const profiles = useLiveQuery(() => db.profile.toArray());
 
     const currentSettings = settings?.[0];
+    const currentProfile = profiles?.[0];
 
     const [isSaving, setIsSaving] = useState(false);
     const [remoteSync, setRemoteSync] = useState(false);
+
+    const [partner1Name, setPartner1Name] = useState('');
+    const [partner1Dob, setPartner1Dob] = useState('');
+    const [partner2Name, setPartner2Name] = useState('');
+    const [partner2Dob, setPartner2Dob] = useState('');
 
     useEffect(() => {
         if (currentSettings) {
             setRemoteSync(currentSettings.icloudSync || false);
         }
     }, [currentSettings]);
+
+    useEffect(() => {
+        if (currentProfile) {
+            setPartner1Name(currentProfile.partner1Name || '');
+            setPartner1Dob(currentProfile.partner1Dob ? new Date(currentProfile.partner1Dob).toISOString().split('T')[0] : '');
+            setPartner2Name(currentProfile.partner2Name || '');
+            setPartner2Dob(currentProfile.partner2Dob ? new Date(currentProfile.partner2Dob).toISOString().split('T')[0] : '');
+        }
+    }, [currentProfile]);
 
     const handleTaxYearChange = async (e: React.ChangeEvent<HTMLSelectElement>) => {
         if (currentSettings) {
@@ -34,12 +51,24 @@ export function SettingsPage() {
     };
 
     const handleSave = async () => {
-        if (currentSettings) {
+        if (currentSettings || currentProfile) {
             setIsSaving(true);
             try {
-                await db.settings.update(currentSettings.id, {
-                    icloudSync: remoteSync,
-                });
+                if (currentSettings) {
+                    await db.settings.update(currentSettings.id, {
+                        icloudSync: remoteSync,
+                    });
+                }
+
+                if (currentProfile) {
+                    await db.profile.update(currentProfile.id, {
+                        name: `${partner1Name.trim()} & ${partner2Name.trim() || 'Partner'}`,
+                        partner1Name: partner1Name.trim(),
+                        partner1Dob: partner1Dob ? new Date(partner1Dob).getTime() : undefined,
+                        partner2Name: partner2Name.trim() || undefined,
+                        partner2Dob: partner2Dob ? new Date(partner2Dob).getTime() : undefined,
+                    });
+                }
                 await new Promise(resolve => setTimeout(resolve, 500));
             } finally {
                 setIsSaving(false);
@@ -106,6 +135,57 @@ export function SettingsPage() {
                                     className="invisible absolute"
                                 />
                             </label>
+                        </div>
+                    </div>
+                </section>
+
+                <section className="mt-8 px-4">
+                    <h2 className="text-xs font-bold uppercase tracking-widest text-slate-500 dark:text-primary/60 mb-3 px-1">Profile</h2>
+                    <div className="bg-white dark:bg-slate-900/40 border border-slate-200 dark:border-primary/5 rounded-xl divide-y divide-slate-100 dark:divide-primary/5 p-4 space-y-4">
+                        <div className="space-y-4">
+                            <div className="grid grid-cols-2 gap-4">
+                                <div className="space-y-2">
+                                    <label htmlFor="partner1Name" className="text-xs font-bold text-slate-500 dark:text-primary/60 uppercase">Partner 1 Name</label>
+                                    <input
+                                        id="partner1Name"
+                                        type="text"
+                                        value={partner1Name}
+                                        onChange={(e) => setPartner1Name(e.target.value)}
+                                        className="w-full bg-slate-50 dark:bg-primary/5 border border-slate-200 dark:border-primary/10 rounded-lg px-3 py-2 outline-none focus:ring-1 focus:ring-primary/30"
+                                    />
+                                </div>
+                                <div className="space-y-2">
+                                    <label htmlFor="partner1Dob" className="text-xs font-bold text-slate-500 dark:text-primary/60 uppercase">Partner 1 DOB</label>
+                                    <DateInput
+                                        id="partner1Dob"
+                                        value={partner1Dob}
+                                        onChange={(e) => setPartner1Dob(e.target.value)}
+                                        className="w-full bg-slate-50 dark:bg-primary/5 border border-slate-200 dark:border-primary/10 rounded-lg px-3 py-2 outline-none focus:ring-1 focus:ring-primary/30"
+                                    />
+                                </div>
+                            </div>
+
+                            <div className="grid grid-cols-2 gap-4">
+                                <div className="space-y-2">
+                                    <label htmlFor="partner2Name" className="text-xs font-bold text-slate-500 dark:text-primary/60 uppercase">Partner 2 Name</label>
+                                    <input
+                                        id="partner2Name"
+                                        type="text"
+                                        value={partner2Name}
+                                        onChange={(e) => setPartner2Name(e.target.value)}
+                                        className="w-full bg-slate-50 dark:bg-primary/5 border border-slate-200 dark:border-primary/10 rounded-lg px-3 py-2 outline-none focus:ring-1 focus:ring-primary/30"
+                                    />
+                                </div>
+                                <div className="space-y-2">
+                                    <label htmlFor="partner2Dob" className="text-xs font-bold text-slate-500 dark:text-primary/60 uppercase">Partner 2 DOB</label>
+                                    <DateInput
+                                        id="partner2Dob"
+                                        value={partner2Dob}
+                                        onChange={(e) => setPartner2Dob(e.target.value)}
+                                        className="w-full bg-slate-50 dark:bg-primary/5 border border-slate-200 dark:border-primary/10 rounded-lg px-3 py-2 outline-none focus:ring-1 focus:ring-primary/30"
+                                    />
+                                </div>
+                            </div>
                         </div>
                     </div>
                 </section>

--- a/src/pages/SimplifiedAppSetupPage.tsx
+++ b/src/pages/SimplifiedAppSetupPage.tsx
@@ -1,6 +1,7 @@
 import { AppLayout } from '@/components/layout/AppLayout';
 import { Icon } from '@/components/ui/Icon';
 import { Button } from '@/components/ui/Button';
+import { DateInput } from '@/components/ui/DateInput';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useStore } from '@/store/useStore';
@@ -12,7 +13,9 @@ export function SimplifiedAppSetupPage() {
     const navigate = useNavigate();
     const { setProfile, initStore } = useStore();
     const [partner1Name, setPartner1Name] = useState('');
+    const [partner1Dob, setPartner1Dob] = useState('');
     const [partner2Name, setPartner2Name] = useState('');
+    const [partner2Dob, setPartner2Dob] = useState('');
     const [syncServerUrl, setSyncServerUrl] = useState('');
     const [syncPassphrase, setSyncPassphrase] = useState('');
     const [syncHeaderKey, setSyncHeaderKey] = useState('');
@@ -31,7 +34,9 @@ export function SimplifiedAppSetupPage() {
             id: 'default',
             name: `${partner1Name.trim()} & ${partner2Name.trim() || 'Partner'}`,
             partner1Name: partner1Name.trim(),
+            partner1Dob: partner1Dob ? new Date(partner1Dob).getTime() : undefined,
             partner2Name: partner2Name.trim() || undefined,
+            partner2Dob: partner2Dob ? new Date(partner2Dob).getTime() : undefined,
             createdAt: Date.now()
         });
 
@@ -135,7 +140,7 @@ export function SimplifiedAppSetupPage() {
                         <div className="space-y-5">
                             {/* Partner 1 */}
                             <div className="space-y-3">
-                                <label className="block text-sm font-semibold text-slate-700 dark:text-slate-300">
+                                <label htmlFor="partner1Name" className="block text-sm font-semibold text-slate-700 dark:text-slate-300">
                                     Partner 1 Name{' '}
                                     <Icon
                                         name="info"
@@ -144,6 +149,7 @@ export function SimplifiedAppSetupPage() {
                                     />
                                 </label>
                                 <input
+                                    id="partner1Name"
                                     type="text"
                                     placeholder="e.g. Alex"
                                     value={partner1Name}
@@ -152,9 +158,22 @@ export function SimplifiedAppSetupPage() {
                                 />
                             </div>
 
-                            {/* Partner 2 */}
+                            {/* Partner 1 DOB */}
                             <div className="space-y-3 pt-2">
-                                <label className="block text-sm font-semibold text-slate-700 dark:text-slate-300">
+                                <label htmlFor="partner1Dob" className="block text-sm font-semibold text-slate-700 dark:text-slate-300">
+                                    Partner 1 Date of Birth (Optional)
+                                </label>
+                                <DateInput
+                                    id="partner1Dob"
+                                    value={partner1Dob}
+                                    onChange={(e) => setPartner1Dob(e.target.value)}
+                                    className="w-full bg-white dark:bg-background-dark border border-primary/20 rounded-lg px-4 py-3 focus:ring-2 focus:ring-primary focus:border-transparent transition-all outline-none"
+                                />
+                            </div>
+
+                            {/* Partner 2 */}
+                            <div className="space-y-3 pt-2 border-t border-primary/10">
+                                <label htmlFor="partner2Name" className="block text-sm font-semibold text-slate-700 dark:text-slate-300">
                                     Partner 2 Name{' '}
                                     <Icon
                                         name="info"
@@ -163,10 +182,24 @@ export function SimplifiedAppSetupPage() {
                                     />
                                 </label>
                                 <input
+                                    id="partner2Name"
                                     type="text"
                                     placeholder="e.g. Sam"
                                     value={partner2Name}
                                     onChange={(e) => setPartner2Name(e.target.value)}
+                                    className="w-full bg-white dark:bg-background-dark border border-primary/20 rounded-lg px-4 py-3 focus:ring-2 focus:ring-primary focus:border-transparent transition-all outline-none"
+                                />
+                            </div>
+
+                            {/* Partner 2 DOB */}
+                            <div className="space-y-3 pt-2">
+                                <label htmlFor="partner2Dob" className="block text-sm font-semibold text-slate-700 dark:text-slate-300">
+                                    Partner 2 Date of Birth (Optional)
+                                </label>
+                                <DateInput
+                                    id="partner2Dob"
+                                    value={partner2Dob}
+                                    onChange={(e) => setPartner2Dob(e.target.value)}
                                     className="w-full bg-white dark:bg-background-dark border border-primary/20 rounded-lg px-4 py-3 focus:ring-2 focus:ring-primary focus:border-transparent transition-all outline-none"
                                 />
                             </div>


### PR DESCRIPTION
This change adds optional Date of Birth fields for both partners to the profile. This is required for future cashflow forecasting features. The fields are integrated into the initial setup flow and the settings page, with full support for database schema versioning, data sanitization, and unit testing.

Fixes #227

---
*PR created automatically by Jules for task [13014272418080015090](https://jules.google.com/task/13014272418080015090) started by @John-Bell*