### PR TITLE
Refactor ProjectionEngine: Resolving `any` types

### DIFF
--- a/src/utils/projectionEngine.ts
+++ b/src/utils/projectionEngine.ts
@@ -1,4 +1,4 @@
-import type { Income } from '../lib/db';
+import type { Income, Budget, Property, PropertyOwnership } from '../lib/db';
 
 export interface ProjectionEngineInput {
   currentBalances: number; // Sum of active balances across liquid pots
@@ -8,9 +8,9 @@ export interface ProjectionEngineInput {
     partner2Dob?: number;  // Epoch timestamp ms
   };
   incomes: Income[];
-  budgets: any[];          // Kept as any[] for this task
-  properties: any[];       // Kept as any[] for this task
-  propertyOwnership: any[]; // Kept as any[] for this task
+  budgets: Budget[];
+  properties: Property[];
+  propertyOwnership: PropertyOwnership[];
 }
 
 export interface ProjectionYearResult {


### PR DESCRIPTION
Replaced remaining `any` type usage in `projectionEngine.ts` inputs to their concrete types (`Budget`, `Property`, `PropertyOwnership`) directly imported from `src/lib/db.ts`.

- Cleaned up leftover `// Kept as any[] for this task` comments.
- Tests and build pass cleanly as these are strictly type-annotation changes.

---
*PR created automatically by Jules for task [6426754643603269676](https://jules.google.com/task/6426754643603269676) started by @John-Bell*