### PR TITLE
Implement Escalated Rental Income & Split Ownership Layer

### DIFF
--- a/src/utils/projectionEngine.ts
+++ b/src/utils/projectionEngine.ts
@@ -79,6 +79,32 @@ export function calculateLifetimeProjection(input: ProjectionEngineInput): Proje
 
     trackingLiquidAssets += totalRegularIncomeForYear;
 
+    let p1RentalGrossForYear = 0;
+    let p2RentalGrossForYear = 0;
+
+    for (const property of input.properties) {
+      // Step A: Escalate Expected Rent
+      const baseMonthly = property.expectedMonthlyIncome ?? 0;
+      const annualBaseRent = baseMonthly * 12;
+      const growthRate = property.annualGrowthRate ?? 0;
+      const escalatedGrossRent = annualBaseRent * Math.pow(1 + growthRate / 100, yearIndex);
+
+      // Step B: Find active ownership split
+      const relevantOwnerships = input.propertyOwnership
+        .filter(o => o.propertyId === property.id && o.startDate <= yearEndTs)
+        .sort((a, b) => b.startDate - a.startDate);
+
+      const activeSplit = relevantOwnerships.length > 0
+        ? relevantOwnerships[0]
+        : { person1Percent: 50, person2Percent: 50 };
+
+      // Step C: Apportion to loop tracking variables
+      p1RentalGrossForYear += escalatedGrossRent * (activeSplit.person1Percent / 100);
+      p2RentalGrossForYear += escalatedGrossRent * (activeSplit.person2Percent / 100);
+    }
+
+    trackingLiquidAssets += (p1RentalGrossForYear + p2RentalGrossForYear);
+
     results.push({
       yearIndex,
       calendarYear: runningCalendarYear,


### PR DESCRIPTION
This commit introduces the necessary logic to `src/utils/projectionEngine.ts` to calculate escalated gross rental income for properties over the simulated lifetime projection. It dynamically apportions this income based on active ownership splits for each year (falling back to an equal 50/50 split when undefined) and integrates it into the global `trackingLiquidAssets` sum.

---
*PR created automatically by Jules for task [10424934231178043797](https://jules.google.com/task/10424934231178043797) started by @John-Bell*