### PR TITLE
Fix build errors in LifetimeProjectionChart and CashflowProjectionPage

### DIFF
--- a/src/components/scenarios/LifetimeProjectionChart.tsx
+++ b/src/components/scenarios/LifetimeProjectionChart.tsx
@@ -86,12 +86,12 @@ const LifetimeProjectionChart: React.FC = () => {
           <AreaChart
             data={data}
             margin={{ top: 10, right: 10, left: -20, bottom: 20 }}
-            onMouseMove={(e) => {
+            onMouseMove={(e: any) => {
               if (e.activePayload) {
                 setActivePoint(e.activePayload[0].payload);
               }
             }}
-            onTouchMove={(e) => {
+            onTouchMove={(e: any) => {
               if (e.activePayload) {
                 setActivePoint(e.activePayload[0].payload);
               }

--- a/src/pages/CashflowProjectionPage.tsx
+++ b/src/pages/CashflowProjectionPage.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { AppLayout } from '../components/layout/AppLayout';
 import { Header } from '../components/layout/Header';
 import { Icon } from '../components/ui/Icon';


### PR DESCRIPTION
This PR fixes TypeScript compilation errors that were causing the build to fail. 

Specifically:
- It removes an unused React import in `src/pages/CashflowProjectionPage.tsx`, which was triggering a `TS6133` error.
- It resolves property access errors on Recharts event objects in `src/components/scenarios/LifetimeProjectionChart.tsx` by using type casting for the event parameters in `onMouseMove` and `onTouchMove`.

These changes ensure that `npm run build` (which includes `tsc -b`) completes successfully.

Fixes #238

---
*PR created automatically by Jules for task [8067196142814738349](https://jules.google.com/task/8067196142814738349) started by @John-Bell*