### PR TITLE
Make lifetime projection chart names dynamic

### DIFF
--- a/src/components/scenarios/LifetimeProjectionChart.tsx
+++ b/src/components/scenarios/LifetimeProjectionChart.tsx
@@ -16,7 +16,7 @@ import { useLifetimeProjection } from '@/hooks/useLifetimeProjection';
  * Designed to prevent scroll hijacking and provide a clear readout header on scrub.
  */
 const LifetimeProjectionChart: React.FC = () => {
-  const { data, isReady } = useLifetimeProjection();
+  const { data, isReady, p1Name, p2Name } = useLifetimeProjection();
   const [activePoint, setActivePoint] = useState<any>(null);
 
   // Loading State
@@ -76,7 +76,7 @@ const LifetimeProjectionChart: React.FC = () => {
           {formatCurrency(displayPoint.liquidAssets)}
         </div>
         <div className="text-xs font-medium text-gray-500 mt-0.5">
-          Year: {displayPoint.calendarYear} | Dan: Age {displayPoint.ageP1} • Freya: Age {displayPoint.ageP2}
+          Year: {displayPoint.calendarYear} | {p1Name}: Age {displayPoint.ageP1} • {p2Name}: Age {displayPoint.ageP2}
         </div>
       </div>
 
@@ -148,8 +148,8 @@ const LifetimeProjectionChart: React.FC = () => {
 
       {/* Optional: Legend for Age Rows */}
       <div className="flex flex-col gap-1 mt-2 text-[10px] text-gray-400 absolute bottom-6 left-4">
-        <span>Dan</span>
-        <span>Freya</span>
+        <span>{p1Name}</span>
+        <span>{p2Name}</span>
       </div>
     </div>
   );

--- a/src/hooks/useLifetimeProjection.ts
+++ b/src/hooks/useLifetimeProjection.ts
@@ -17,14 +17,16 @@ export function useLifetimeProjection() {
   return useMemo(() => {
     // Fallback Boundary
     if (!dbProfile || dbProfile.length === 0 || !dbProfile[0].partner1Dob) {
-      return { data: [] as ProjectionYearResult[], isReady: false };
+      return { data: [] as ProjectionYearResult[], isReady: false, p1Name: 'Partner 1', p2Name: 'Partner 2' };
     }
 
     const activeProfile = dbProfile[0];
+    const p1Name = activeProfile.partner1Name || 'Partner 1';
+    const p2Name = activeProfile.partner2Name || 'Partner 2';
 
     // Ensure dependent data are loaded
     if (!dbAccounts || !dbIncomes || !dbBudgets || !dbProperties || !dbPropertyOwnership || !dbTaxRules) {
-      return { data: [] as ProjectionYearResult[], isReady: false };
+      return { data: [] as ProjectionYearResult[], isReady: false, p1Name, p2Name };
     }
 
     // Calculate Initial Capital Pool
@@ -100,7 +102,9 @@ export function useLifetimeProjection() {
 
     return {
       data: projectionData,
-      isReady: true
+      isReady: true,
+      p1Name,
+      p2Name
     };
   }, [
     dbProfile,


### PR DESCRIPTION
Replaces hardcoded names in the `LifetimeProjectionChart` with dynamic names retrieved from the database profile.
- Updates `useLifetimeProjection` to extract and return `p1Name` and `p2Name`
- Modifies `LifetimeProjectionChart` to utilize the dynamic names in its header panel and chart legend

---
*PR created automatically by Jules for task [12916431297174959494](https://jules.google.com/task/12916431297174959494) started by @John-Bell*