### PR TITLE
fix: include Stocks & Shares and Premium Bonds in cashflow projection

### DIFF
--- a/src/hooks/useLifetimeProjection.ts
+++ b/src/hooks/useLifetimeProjection.ts
@@ -37,7 +37,9 @@ export function useLifetimeProjection() {
       'Notice Savings',
       'Cash ISA',
       'Shares ISA',
-      'DC Pension'
+      'DC Pension',
+      'Stocks & Shares',
+      'Premium Bonds'
     ];
 
     const totalLiquidBalances = dbAccounts


### PR DESCRIPTION
Fix cashflow projection to include Stocks & Shares and Premium Bonds.

---
*PR created automatically by Jules for task [4122845884068995770](https://jules.google.com/task/4122845884068995770) started by @John-Bell*