### PR TITLE
feat: add adjustable default growth rate for cashflow projections

### DIFF
--- a/src/components/scenarios/LifetimeProjectionChart.tsx
+++ b/src/components/scenarios/LifetimeProjectionChart.tsx
@@ -16,7 +16,7 @@ import { useLifetimeProjection } from '@/hooks/useLifetimeProjection';
  * Designed to prevent scroll hijacking and provide a clear readout header on scrub.
  */
 const LifetimeProjectionChart: React.FC = () => {
-  const { data, isReady, p1Name, p2Name } = useLifetimeProjection();
+  const { data, isReady, p1Name, p2Name, growthRate } = useLifetimeProjection();
   const [activePoint, setActivePoint] = useState<any>(null);
 
   // Loading State
@@ -77,7 +77,7 @@ const LifetimeProjectionChart: React.FC = () => {
       {/* A. STATIC ASSUMPTIONS OVERLAY BADGE */}
       <div className="mt-4 mb-6 md:mt-0 md:mb-0 relative block w-full md:absolute md:top-4 md:right-4 z-10 p-2 text-[10px] text-gray-500 md:max-w-[200px] rounded-lg bg-gray-50 border border-slate-100 leading-relaxed pointer-events-none">
         <span className="font-bold block mb-0.5">Assumptions</span>
-        Real Investment Growth: 2.38% (net of fees). We use conservative growth assumptions given the unpredictability of stock/bond returns and inflation.
+        Real Investment Growth: {growthRate}% (net of fees). We use conservative growth assumptions given the unpredictability of stock/bond returns and inflation.
       </div>
 
       {/* C. THE RECHARTS GRAPH CANVAS */}

--- a/src/hooks/useLifetimeProjection.ts
+++ b/src/hooks/useLifetimeProjection.ts
@@ -13,11 +13,12 @@ export function useLifetimeProjection() {
   const dbProperties = useLiveQuery(() => db.properties.toArray());
   const dbPropertyOwnership = useLiveQuery(() => db.propertyOwnership.toArray());
   const dbTaxRules = useLiveQuery(() => db.taxRules.toArray());
+  const dbSettings = useLiveQuery(() => db.settings.toArray());
 
   return useMemo(() => {
     // Fallback Boundary
     if (!dbProfile || dbProfile.length === 0 || !dbProfile[0].partner1Dob) {
-      return { data: [] as ProjectionYearResult[], isReady: false, p1Name: 'Partner 1', p2Name: 'Partner 2' };
+      return { data: [] as ProjectionYearResult[], isReady: false, p1Name: 'Partner 1', p2Name: 'Partner 2', growthRate: 1.75 };
     }
 
     const activeProfile = dbProfile[0];
@@ -25,9 +26,11 @@ export function useLifetimeProjection() {
     const p2Name = activeProfile.partner2Name || 'Partner 2';
 
     // Ensure dependent data are loaded
-    if (!dbAccounts || !dbIncomes || !dbBudgets || !dbProperties || !dbPropertyOwnership || !dbTaxRules) {
-      return { data: [] as ProjectionYearResult[], isReady: false, p1Name, p2Name };
+    if (!dbAccounts || !dbIncomes || !dbBudgets || !dbProperties || !dbPropertyOwnership || !dbTaxRules || !dbSettings) {
+      return { data: [] as ProjectionYearResult[], isReady: false, p1Name, p2Name, growthRate: 1.75 };
     }
+
+    const growthRate = dbSettings[0]?.defaultGrowthRate ?? 1.75;
 
     // Calculate Initial Capital Pool
     const liquidCategories = [
@@ -90,7 +93,7 @@ export function useLifetimeProjection() {
     // Execute Engine Matrix
     const projectionData = calculateLifetimeProjection({
       currentBalances: totalLiquidBalances,
-      realGrowthRate: 2.38,
+      realGrowthRate: growthRate,
       profile: {
         partner1Dob: activeProfile.partner1Dob as number,
         partner2Dob: activeProfile.partner2Dob
@@ -106,7 +109,8 @@ export function useLifetimeProjection() {
       data: projectionData,
       isReady: true,
       p1Name,
-      p2Name
+      p2Name,
+      growthRate
     };
   }, [
     dbProfile,
@@ -115,6 +119,7 @@ export function useLifetimeProjection() {
     dbBudgets,
     dbProperties,
     dbPropertyOwnership,
-    dbTaxRules
+    dbTaxRules,
+    dbSettings
   ]);
 }

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -83,6 +83,7 @@ export interface Settings {
     syncServerUrl?: string;
     syncPassphrase?: string;
     syncHeaderKey?: string;
+    defaultGrowthRate?: number;
 }
 
 export interface MonthlyArchive {

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -22,6 +22,7 @@ export function SettingsPage() {
 
     const [isSaving, setIsSaving] = useState(false);
     const [remoteSync, setRemoteSync] = useState(false);
+    const [defaultGrowthRate, setDefaultGrowthRate] = useState<number>(1.75);
 
     const [partner1Name, setPartner1Name] = useState('');
     const [partner1Dob, setPartner1Dob] = useState('');
@@ -31,6 +32,7 @@ export function SettingsPage() {
     useEffect(() => {
         if (currentSettings) {
             setRemoteSync(currentSettings.icloudSync || false);
+            setDefaultGrowthRate(currentSettings.defaultGrowthRate ?? 1.75);
         }
     }, [currentSettings]);
 
@@ -57,6 +59,7 @@ export function SettingsPage() {
                 if (currentSettings) {
                     await db.settings.update(currentSettings.id, {
                         icloudSync: remoteSync,
+                        defaultGrowthRate: defaultGrowthRate,
                     });
                 }
 
@@ -203,6 +206,24 @@ export function SettingsPage() {
                             <div className="flex items-center gap-2 text-primary font-semibold">
                                 <span>GBP (£)</span>
                                 <Icon name="chevron_right" className="text-sm" />
+                            </div>
+                        </div>
+
+                        <div className="flex items-center justify-between p-4">
+                            <div className="flex items-center gap-4">
+                                <div className="flex items-center justify-center w-10 h-10 rounded-lg bg-slate-100 dark:bg-primary/5 text-slate-600 dark:text-primary/80">
+                                    <Icon name="trending_up" />
+                                </div>
+                                <p className="font-medium">Default Real Growth Rate (%)</p>
+                            </div>
+                            <div className="flex items-center gap-2">
+                                <input
+                                    type="number"
+                                    step="0.01"
+                                    value={defaultGrowthRate}
+                                    onChange={(e) => setDefaultGrowthRate(parseFloat(e.target.value) || 0)}
+                                    className="w-20 bg-slate-50 dark:bg-primary/5 border border-slate-200 dark:border-primary/10 rounded-lg px-3 py-2 outline-none focus:ring-1 focus:ring-primary/30 text-right"
+                                />
                             </div>
                         </div>
 

--- a/src/pages/SimplifiedAppSetupPage.tsx
+++ b/src/pages/SimplifiedAppSetupPage.tsx
@@ -50,6 +50,7 @@ export function SimplifiedAppSetupPage() {
             syncServerUrl: syncServerUrl.trim() || undefined,
             syncPassphrase: syncPassphrase.trim() || undefined,
             syncHeaderKey: syncHeaderKey.trim() || undefined,
+            defaultGrowthRate: existingSettings?.defaultGrowthRate ?? 1.75,
             updatedAt: Date.now()
         });
 
@@ -89,6 +90,7 @@ export function SimplifiedAppSetupPage() {
                 syncServerUrl: restoreSyncServerUrl.trim() || undefined,
                 syncPassphrase: restoreSyncPassphrase.trim() || undefined,
                 syncHeaderKey: restoreSyncHeaderKey.trim() || undefined,
+                defaultGrowthRate: existingSettings?.defaultGrowthRate ?? 1.75,
                 lastSynced: Date.now(),
                 updatedAt: Date.now()
             });


### PR DESCRIPTION
This PR changes the default growth rate on the cashflow projection from 2.38 to 1.75. It also adds a text box in the application settings page to enable this to be adjusted manually and saved to the settings table.

---
*PR created automatically by Jules for task [14368955422898566052](https://jules.google.com/task/14368955422898566052) started by @John-Bell*