### PR TITLE
Add annual budget and net cash flow metrics to projection engine output

### DIFF
--- a/src/utils/projectionEngine.ts
+++ b/src/utils/projectionEngine.ts
@@ -24,6 +24,8 @@ export interface ProjectionYearResult {
   liquidAssets: number;
   isRunwayBroken: boolean;
   milestones: string[];
+  annualBudget: number;
+  netCashFlow: number;
 }
 
 function calculateAge(dobTimestamp: number, currentDate: Date): number {
@@ -174,7 +176,9 @@ export function calculateLifetimeProjection(input: ProjectionEngineInput): Proje
       ageP2: currentAgeP2,
       liquidAssets: trackingLiquidAssets,
       isRunwayBroken: isRunwayBroken,
-      milestones: []
+      milestones: [],
+      annualBudget: totalBudgetsForYear,
+      netCashFlow: netCashFlow
     });
 
     if (currentAgeP1 >= 100) {


### PR DESCRIPTION
Updates the projection calculation engine to output annual budget outlays and total net cash flow for each projected year, supporting future visualizations and chart readouts.

---
*PR created automatically by Jules for task [11425496949269148586](https://jules.google.com/task/11425496949269148586) started by @John-Bell*