### PR TITLE
Fix Recharts touch events on mobile

### DIFF
--- a/src/components/scenarios/LifetimeProjectionChart.tsx
+++ b/src/components/scenarios/LifetimeProjectionChart.tsx
@@ -110,17 +110,26 @@ const LifetimeProjectionChart: React.FC = () => {
           <AreaChart
             data={data}
             margin={{ top: 10, right: 10, left: -20, bottom: 20 }}
+            onClick={(e: any) => {
+              if (e && e.activePayload && e.activePayload.length > 0) {
+                setActivePoint(e.activePayload[0].payload);
+              }
+            }}
+            onTouchStart={(e: any) => {
+              if (e && e.activePayload && e.activePayload.length > 0) {
+                setActivePoint(e.activePayload[0].payload);
+              }
+            }}
             onMouseMove={(e: any) => {
-              if (e.activePayload) {
+              if (e && e.activePayload && e.activePayload.length > 0) {
                 setActivePoint(e.activePayload[0].payload);
               }
             }}
             onTouchMove={(e: any) => {
-              if (e.activePayload) {
+              if (e && e.activePayload && e.activePayload.length > 0) {
                 setActivePoint(e.activePayload[0].payload);
               }
             }}
-            onMouseLeave={() => setActivePoint(null)}
           >
             <defs>
               <linearGradient id="colorAssets" x1="0" y1="0" x2="0" y2="1">


### PR DESCRIPTION
Re-wrote Recharts component properties to address missing data metrics on mobile touch. Included the addition of `onTouchStart` and `onClick`, payload data integrity checks during continuous scrub (`onTouchMove`/`onMouseMove`), and the removal of the `onMouseLeave` state wipe to maintain on-screen metric selection.

---
*PR created automatically by Jules for task [11280555826742503489](https://jules.google.com/task/11280555826742503489) started by @John-Bell*