### PR TITLE
Add getTaxYearOrLatest for future projections

### DIFF
--- a/src/constants/taxConstants.ts
+++ b/src/constants/taxConstants.ts
@@ -293,6 +293,21 @@ export const getDefaultTaxYear = (taxYear?: string): string => {
   return requestedYear ?? (TAX_YEAR_CONSTANTS[currentYear] ? currentYear : DEFAULT_TAX_YEAR);
 };
 
+export const getTaxYearOrLatest = (taxYear?: string): string => {
+  if (taxYear && TAX_YEAR_CONSTANTS[taxYear]) {
+    return taxYear;
+  }
+  if (taxYear) {
+    // If a tax year was requested but doesn't exist, find the latest available
+    const availableYears = Object.keys(TAX_YEAR_CONSTANTS).sort();
+    if (availableYears.length > 0) {
+      return availableYears[availableYears.length - 1];
+    }
+  }
+  const currentYear = getCurrentTaxYearKey();
+  return TAX_YEAR_CONSTANTS[currentYear] ? currentYear : DEFAULT_TAX_YEAR;
+};
+
 export const getTaxYearDates = (taxYear?: string): { startTs: number; endTs: number } => {
   const resolvedYear = getDefaultTaxYear(taxYear);
   const startYearStr = resolvedYear.split('-')[0];


### PR DESCRIPTION
Adds `getTaxYearOrLatest` function to `taxConstants.ts`. This utility returns the exact tax year key if it exists, or the latest available tax year key if a requested future year is missing. This provides safe fallback logic for the cashflow projection engine as it simulates decades into the future.

---
*PR created automatically by Jules for task [16281644783026297959](https://jules.google.com/task/16281644783026297959) started by @John-Bell*