### PR TITLE
Fix cashflow projection engine tax year resolution

### DIFF
--- a/src/services/DividendTaxService.ts
+++ b/src/services/DividendTaxService.ts
@@ -1,4 +1,4 @@
-import { getDefaultTaxYear, type TaxRulesByYear } from '../constants/taxConstants';
+import { getTaxYearOrLatest, type TaxRulesByYear } from '../constants/taxConstants';
 import { BrbTracker } from '../models/BrbTracker';
 import type { TaxBandResult } from '../models/TaxBandResult';
 
@@ -12,7 +12,7 @@ export class DividendTaxService {
   }
 
   calculateDividendTax(dividendIncome: number, brbTracker: BrbTracker, taxYear?: string): TaxBandResult[] {
-    const resolvedTaxYear = getDefaultTaxYear(taxYear ?? this.taxYear);
+    const resolvedTaxYear = getTaxYearOrLatest(taxYear ?? this.taxYear);
     const taxConstants = this.taxRules[resolvedTaxYear];
     const taxBands: TaxBandResult[] = [];
     if (dividendIncome <= 0) return taxBands;

--- a/src/services/GeneralTaxService.ts
+++ b/src/services/GeneralTaxService.ts
@@ -1,4 +1,4 @@
-import { getDefaultTaxYear, type TaxRulesByYear } from '../constants/taxConstants';
+import { getTaxYearOrLatest, type TaxRulesByYear } from '../constants/taxConstants';
 import { BrbTracker } from '../models/BrbTracker';
 import type { TaxBandResult } from '../models/TaxBandResult';
 
@@ -16,7 +16,7 @@ export class GeneralTaxService {
     brbTracker: BrbTracker,
     taxYear?: string
   ): TaxBandResult[] {
-    const resolvedTaxYear = getDefaultTaxYear(taxYear ?? this.taxYear);
+    const resolvedTaxYear = getTaxYearOrLatest(taxYear ?? this.taxYear);
     const taxConstants = this.taxRules[resolvedTaxYear];
     const taxBands: TaxBandResult[] = [];
     let remainingIncome = income;

--- a/src/services/PropertyTaxService.ts
+++ b/src/services/PropertyTaxService.ts
@@ -1,4 +1,4 @@
-import { getDefaultTaxYear, type TaxRulesByYear } from '@/constants/taxConstants';
+import { getTaxYearOrLatest, type TaxRulesByYear } from '@/constants/taxConstants';
 import { BrbTracker } from '@/models/BrbTracker';
 import { PersonalAllowanceTracker } from '@/models/PersonalAllowanceTracker';
 import type { TaxBandResult } from '@/models/TaxBandResult';
@@ -17,7 +17,7 @@ export class PropertyTaxService {
         propertyExpenses: number = 0,
         taxYear?: string
     ): { taxablePropertyIncome: number; propertyAllowanceApplied: boolean } {
-        const resolvedTaxYear = getDefaultTaxYear(taxYear ?? this.taxYear);
+        const resolvedTaxYear = getTaxYearOrLatest(taxYear ?? this.taxYear);
         const taxConstants = this.taxRules[resolvedTaxYear];
 
         let taxablePropertyIncome = 0;
@@ -41,7 +41,7 @@ export class PropertyTaxService {
         brbTracker: BrbTracker,
         taxYear?: string
     ): { taxBands: TaxBandResult[]; propertyAllowanceApplied: boolean; taxablePropertyIncome: number } {
-        const resolvedTaxYear = getDefaultTaxYear(taxYear ?? this.taxYear);
+        const resolvedTaxYear = getTaxYearOrLatest(taxYear ?? this.taxYear);
         const taxConstants = this.taxRules[resolvedTaxYear];
         const taxBands: TaxBandResult[] = [];
 

--- a/src/services/SavingsTaxService.ts
+++ b/src/services/SavingsTaxService.ts
@@ -1,4 +1,4 @@
-import { getDefaultTaxYear, type TaxRulesByYear } from '../constants/taxConstants';
+import { getTaxYearOrLatest, type TaxRulesByYear } from '../constants/taxConstants';
 import { BrbTracker } from '../models/BrbTracker';
 import type { TaxBandResult } from '../models/TaxBandResult';
 
@@ -19,7 +19,7 @@ export class SavingsTaxService {
     generalTaxBands: TaxBandResult[] = [],
     taxYear?: string
   ): TaxBandResult[] {
-    const resolvedTaxYear = getDefaultTaxYear(taxYear ?? this.taxYear);
+    const resolvedTaxYear = getTaxYearOrLatest(taxYear ?? this.taxYear);
     const taxConstants = this.taxRules[resolvedTaxYear];
     const taxBands: TaxBandResult[] = [];
     if (savingsIncome <= 0) return taxBands;

--- a/src/services/TaxCalculationService.ts
+++ b/src/services/TaxCalculationService.ts
@@ -1,4 +1,4 @@
-import { getDefaultTaxYear, getTaxConstants, type TaxRulesByYear } from '../constants/taxConstants';
+import { getTaxYearOrLatest, getTaxConstants, type TaxRulesByYear } from '../constants/taxConstants';
 import { BrbTracker } from '../models/BrbTracker';
 import { PersonalAllowanceTracker } from '../models/PersonalAllowanceTracker';
 import type { TaxCalculationInput } from '../models/TaxCalculationInput';
@@ -27,7 +27,7 @@ export class TaxCalculationService {
   }
 
   calculateTax(input: TaxCalculationInput, taxYear?: string): TaxCalculationResult {
-    const resolvedTaxYear = getDefaultTaxYear(taxYear ?? this.taxYear);
+    const resolvedTaxYear = getTaxYearOrLatest(taxYear ?? this.taxYear);
     const taxConstants = this.taxRules[resolvedTaxYear];
     const incomeBreakdown: IncomeBreakdown = this.calculateIncomeBreakdown(input);
     const taxByBand: TaxBandResult[] = [];


### PR DESCRIPTION
Fix cashflow projection engine tax year resolution

Updated TaxCalculationService and its child tax services (General, Savings, Dividend, and Property) to use `getTaxYearOrLatest` instead of `getDefaultTaxYear`. This ensures that when the cashflow projection engine generates future tax year strings (e.g. 2030-2031), they correctly resolve to the latest available tax year constants rather than incorrectly defaulting to an earlier tax year.

---
*PR created automatically by Jules for task [17102513215531340032](https://jules.google.com/task/17102513215531340032) started by @John-Bell*