### PR TITLE
Refactor: Replace getDefaultTaxYear with getTaxYearOrLatest

### DIFF
--- a/src/constants/taxConstants.ts
+++ b/src/constants/taxConstants.ts
@@ -287,12 +287,6 @@ export const getTaxConstants = (taxYear?: string): TaxYearConstants => {
   return TAX_YEAR_CONSTANTS[resolvedYear];
 };
 
-export const getDefaultTaxYear = (taxYear?: string): string => {
-  const requestedYear = taxYear && TAX_YEAR_CONSTANTS[taxYear] ? taxYear : undefined;
-  const currentYear = getCurrentTaxYearKey();
-  return requestedYear ?? (TAX_YEAR_CONSTANTS[currentYear] ? currentYear : DEFAULT_TAX_YEAR);
-};
-
 export const getTaxYearOrLatest = (taxYear?: string): string => {
   if (taxYear && TAX_YEAR_CONSTANTS[taxYear]) {
     return taxYear;
@@ -309,7 +303,7 @@ export const getTaxYearOrLatest = (taxYear?: string): string => {
 };
 
 export const getTaxYearDates = (taxYear?: string): { startTs: number; endTs: number } => {
-  const resolvedYear = getDefaultTaxYear(taxYear);
+  const resolvedYear = getTaxYearOrLatest(taxYear);
   const startYearStr = resolvedYear.split('-')[0];
   const startYear = parseInt(startYearStr, 10);
 

--- a/src/pages/PropertiesPage.tsx
+++ b/src/pages/PropertiesPage.tsx
@@ -4,11 +4,11 @@ import { db } from '@/lib/db';
 import { AppLayout } from '@/components/layout/AppLayout';
 import { Header } from '@/components/layout/Header';
 import { Icon } from '@/components/ui/Icon';
-import { getDefaultTaxYear, getTaxYearDates } from '@/constants/taxConstants';
+import { getTaxYearOrLatest, getTaxYearDates } from '@/constants/taxConstants';
 
 export function PropertiesPage() {
     const [searchParams, setSearchParams] = useSearchParams();
-    const defaultTaxYear = getDefaultTaxYear();
+    const defaultTaxYear = getTaxYearOrLatest();
     const taxYearFilter = searchParams.get('taxYear') || defaultTaxYear;
 
     const properties = useLiveQuery(() => db.properties.toArray(), []);

--- a/src/pages/PropertyExpensesPage.tsx
+++ b/src/pages/PropertyExpensesPage.tsx
@@ -4,12 +4,12 @@ import { db } from '@/lib/db';
 import { AppLayout } from '@/components/layout/AppLayout';
 import { Header } from '@/components/layout/Header';
 import { Icon } from '@/components/ui/Icon';
-import { getDefaultTaxYear, getTaxYearDates } from '@/constants/taxConstants';
+import { getTaxYearOrLatest, getTaxYearDates } from '@/constants/taxConstants';
 
 export function PropertyExpensesPage() {
     const [searchParams, setSearchParams] = useSearchParams();
     const propertyIdFilter = searchParams.get('propertyId') || 'all';
-    const defaultTaxYear = getDefaultTaxYear();
+    const defaultTaxYear = getTaxYearOrLatest();
     const taxYearFilter = searchParams.get('taxYear') || defaultTaxYear;
 
     const properties = useLiveQuery(() => db.properties.toArray(), []) || [];

--- a/src/pages/PropertyIncomesPage.tsx
+++ b/src/pages/PropertyIncomesPage.tsx
@@ -4,12 +4,12 @@ import { db } from '@/lib/db';
 import { AppLayout } from '@/components/layout/AppLayout';
 import { Header } from '@/components/layout/Header';
 import { Icon } from '@/components/ui/Icon';
-import { getDefaultTaxYear, getTaxYearDates } from '@/constants/taxConstants';
+import { getTaxYearOrLatest, getTaxYearDates } from '@/constants/taxConstants';
 
 export function PropertyIncomesPage() {
     const [searchParams, setSearchParams] = useSearchParams();
     const propertyIdFilter = searchParams.get('propertyId') || 'all';
-    const defaultTaxYear = getDefaultTaxYear();
+    const defaultTaxYear = getTaxYearOrLatest();
     const taxYearFilter = searchParams.get('taxYear') || defaultTaxYear;
 
     const properties = useLiveQuery(() => db.properties.toArray(), []) || [];

--- a/src/pages/SimplifiedAppSetupPage.tsx
+++ b/src/pages/SimplifiedAppSetupPage.tsx
@@ -6,7 +6,7 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useStore } from '@/store/useStore';
 import { db } from '@/lib/db';
-import { getDefaultTaxYear } from '@/constants/taxConstants';
+import { getTaxYearOrLatest } from '@/constants/taxConstants';
 import { decryptData, mergeData } from '@/services/remoteSyncService';
 
 export function SimplifiedAppSetupPage() {
@@ -45,7 +45,7 @@ export function SimplifiedAppSetupPage() {
         await db.settings.put({
             id: 'default',
             currency: existingSettings?.currency || 'GBP',
-            taxYear: existingSettings?.taxYear || getDefaultTaxYear(),
+            taxYear: existingSettings?.taxYear || getTaxYearOrLatest(),
             icloudSync: existingSettings?.icloudSync || false,
             syncServerUrl: syncServerUrl.trim() || undefined,
             syncPassphrase: syncPassphrase.trim() || undefined,
@@ -85,7 +85,7 @@ export function SimplifiedAppSetupPage() {
             await db.settings.put({
                 id: 'default',
                 currency: existingSettings?.currency || 'GBP',
-                taxYear: existingSettings?.taxYear || getDefaultTaxYear(),
+                taxYear: existingSettings?.taxYear || getTaxYearOrLatest(),
                 icloudSync: existingSettings?.icloudSync || false,
                 syncServerUrl: restoreSyncServerUrl.trim() || undefined,
                 syncPassphrase: restoreSyncPassphrase.trim() || undefined,

--- a/src/store/useStore.ts
+++ b/src/store/useStore.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand';
 import { db, initDb, type Profile } from '@/lib/db';
 import { syncTaxRules } from '@/lib/seed';
-import { getDefaultTaxYear, type TaxRulesByYear } from '@/constants/taxConstants';
+import { getTaxYearOrLatest, type TaxRulesByYear } from '@/constants/taxConstants';
 
 export interface AppState {
     isHydrated: boolean;
@@ -56,7 +56,7 @@ export const useStore = create<AppState>()((set) => ({
 
             // Get the current settings to find the tax year
             const settings = await db.settings.get('default');
-            const currentTaxYear = settings?.taxYear || getDefaultTaxYear();
+            const currentTaxYear = settings?.taxYear || getTaxYearOrLatest();
 
             set({
                 isHydrated: true,


### PR DESCRIPTION
Refactored the application to use `getTaxYearOrLatest` for tax year resolution. 

This ensures more robust calculations during long-term lifetime projections, avoiding cases where future years default backwards incorrectly. The previous implementation (`getDefaultTaxYear`) has been safely removed.

---
*PR created automatically by Jules for task [14904952909482167686](https://jules.google.com/task/14904952909482167686) started by @John-Bell*