### PR TITLE
fix: getTaxYearDates uses strict requested year or current year

### DIFF
--- a/src/constants/taxConstants.ts
+++ b/src/constants/taxConstants.ts
@@ -303,8 +303,10 @@ export const getTaxYearOrLatest = (taxYear?: string): string => {
 };
 
 export const getTaxYearDates = (taxYear?: string): { startTs: number; endTs: number } => {
-  const resolvedYear = getTaxYearOrLatest(taxYear);
-  const startYearStr = resolvedYear.split('-')[0];
+  // CRITICAL FIX: Do NOT use getTaxYearOrLatest here.
+  // Parse exactly the string requested, or fallback to the current real-world year.
+  const resolvedYearStr = taxYear ?? getCurrentTaxYearKey();
+  const startYearStr = resolvedYearStr.split('-')[0];
   const startYear = parseInt(startYearStr, 10);
 
   // UK tax year: 6th April to 5th April


### PR DESCRIPTION
Fixed the logic in `getTaxYearDates` to strictly use the requested `taxYear` string or fall back to the real-world current year.
Previously it was inappropriately routing through `getTaxYearOrLatest` which could mutate the resolved string to an unexpected latest available key instead of evaluating dates literally.

---
*PR created automatically by Jules for task [11288878529537391014](https://jules.google.com/task/11288878529537391014) started by @John-Bell*