### PR TITLE
Correctly handle annual interest accounts in forecasting

### DIFF
--- a/src/utils/forecastUtils.ts
+++ b/src/utils/forecastUtils.ts
@@ -24,7 +24,7 @@ export function calculateHybridForecastForAccount(
     // Step 4: "Projection End Date"
     let projectionEndDate = taxYearEnd;
     if (
-        account.interestPayoutFrequency === 'at_maturity' &&
+        (account.interestPayoutFrequency === 'at_maturity' || account.interestPayoutFrequency === 'annually') &&
         account.interestPayoutDate
     ) {
         if (account.interestPayoutDate <= taxYearEnd) {
@@ -42,19 +42,23 @@ export function calculateHybridForecastForAccount(
         const balance = account.balance || 0;
         const isCompound = account.isCompound === undefined ? true : account.isCompound;
 
+        const isLumpSumFrequency = account.interestPayoutFrequency === 'at_maturity' || account.interestPayoutFrequency === 'annually';
+        const lumpSumYears = account.interestPayoutFrequency === 'annually'
+            ? 1 // Annual payout is always 1 year of interest
+            : (account.bondTermYears || 0);
+
         if (
-            account.interestPayoutFrequency === 'at_maturity' &&
+            isLumpSumFrequency &&
             account.interestPayoutDate &&
             account.interestPayoutDate <= taxYearEnd &&
             account.interestPayoutDate >= taxYearStart &&
-            account.bondTermYears &&
-            account.bondTermYears > 0
+            lumpSumYears > 0
         ) {
             // Full Lump Sum Realized
             if (isCompound) {
-                futureProjection = balance * (Math.pow(1 + rate, account.bondTermYears) - 1);
+                futureProjection = balance * (Math.pow(1 + rate, lumpSumYears) - 1);
             } else {
-                futureProjection = balance * rate * account.bondTermYears;
+                futureProjection = balance * rate * lumpSumYears;
             }
         } else {
             if (isCompound) {


### PR DESCRIPTION
Accounts with annual interest payouts were not being projected correctly because the forecasting engine only looked for 'at_maturity' frequency when determining lump-sum payouts.

This change:
1. Expands the lump-sum logic in `forecastUtils.ts` to include the 'annually' frequency.
2. Updates Step 4 to cap the projection at the `interestPayoutDate` for both 'at_maturity' and 'annually' accounts.
3. Updates Step 5 to calculate a full lump sum of interest for 'annually' accounts (defaulting to 1 year of interest) if the payout date falls within the tax year.
4. Refines the logic to ensure 'annually' accounts always calculate exactly 1 year of interest, even if a multi-year `bondTermYears` is specified, while 'at_maturity' accounts continue to use the full bond term.

Verified with unit tests covering various scenarios, including payouts within/outside the tax year and multi-year annual bonds.

Fixes #254

---
*PR created automatically by Jules for task [520845402409457864](https://jules.google.com/task/520845402409457864) started by @John-Bell*