### PR TITLE
Remove side menu section heading 'CASHFLOW PROJECTION'

### DIFF
--- a/src/components/layout/SideMenu.tsx
+++ b/src/components/layout/SideMenu.tsx
@@ -73,7 +73,6 @@ export function SideMenu({ isOpen, onClose }: SideMenuProps) {
                             Simulator
                         </span>
                     </button>
-                    <div className="px-3 pt-4 pb-1 text-xs font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400">Cashflow Projection</div>
                     <button
                         type="button"
                         onClick={() => handleNavigate('/cashflow-projection')}


### PR DESCRIPTION
Removed the 'CASHFLOW PROJECTION' section heading from the side menu in `src/components/layout/SideMenu.tsx`. This simplifies the UI and removes redundancy since the link below it already carries the same name. Verified via tests and frontend screenshots.

Fixes #257

---
*PR created automatically by Jules for task [9649829318944842588](https://jules.google.com/task/9649829318944842588) started by @John-Bell*