### PR TITLE
Add Asset Composition Page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,6 +31,7 @@ import { AddPropertyOwnershipPage } from '@/pages/AddPropertyOwnershipPage';
 import { EditPropertyOwnershipPage } from '@/pages/EditPropertyOwnershipPage';
 import { SimulatorPage } from '@/pages/SimulatorPage';
 import { CashflowProjectionPage } from '@/pages/CashflowProjectionPage';
+import { AssetCompositionPage } from '@/pages/AssetCompositionPage';
 import { useStore } from '@/store/useStore';
 import { remoteSyncService } from '@/services/remoteSyncService';
 import { dbHooks } from '@/lib/db';
@@ -92,6 +93,7 @@ function AppRoutes() {
       <Route path="/property-ownerships/edit/:id" element={<EditPropertyOwnershipPage />} />
       <Route path="/simulator" element={<SimulatorPage />} />
       <Route path="/cashflow-projection" element={<CashflowProjectionPage />} />
+      <Route path="/asset-composition" element={<AssetCompositionPage />} />
       {/* Setup Routes */}
       <Route path="/setup" element={<SimplifiedAppSetupPage />} />
 

--- a/src/components/layout/SideMenu.tsx
+++ b/src/components/layout/SideMenu.tsx
@@ -87,6 +87,18 @@ export function SideMenu({ isOpen, onClose }: SideMenuProps) {
                     </button>
                     <button
                         type="button"
+                        onClick={() => handleNavigate('/asset-composition')}
+                        className="flex items-center gap-4 w-full p-3 rounded-xl hover:bg-slate-100 dark:hover:bg-surface-dark transition-colors text-left cursor-pointer group"
+                    >
+                        <div className="w-10 h-10 rounded-full bg-slate-200 dark:bg-black/30 flex items-center justify-center text-slate-700 dark:text-slate-300 group-hover:text-primary transition-colors">
+                            <Icon name="pie_chart" className="text-xl" />
+                        </div>
+                        <span className="font-semibold text-slate-700 dark:text-slate-200 group-hover:text-slate-900 dark:group-hover:text-white transition-colors">
+                            Asset Composition
+                        </span>
+                    </button>
+                    <button
+                        type="button"
                         onClick={() => handleNavigate('/settings')}
                         className="flex items-center gap-4 w-full p-3 rounded-xl hover:bg-slate-100 dark:hover:bg-surface-dark transition-colors text-left cursor-pointer group"
                     >

--- a/src/pages/AssetCompositionPage.tsx
+++ b/src/pages/AssetCompositionPage.tsx
@@ -1,0 +1,130 @@
+import { useLiveQuery } from 'dexie-react-hooks';
+import { db } from '@/lib/db';
+import { AppLayout } from '@/components/layout/AppLayout';
+import { Header } from '@/components/layout/Header';
+import { Icon } from '@/components/ui/Icon';
+import { PieChart, Pie, Cell, ResponsiveContainer, Tooltip, Legend } from 'recharts';
+
+const COLORS = [
+    '#0088FE', '#00C49F', '#FFBB28', '#FF8042', '#8884d8',
+    '#82ca9d', '#ffc658', '#8dd1e1', '#a4de6c', '#d0ed57'
+];
+
+export function AssetCompositionPage() {
+    const accounts = useLiveQuery(() => db.accounts.toArray()) || [];
+
+    const categoryDataMap = accounts.reduce((acc, account) => {
+        const category = account.category || 'Uncategorized';
+        acc[category] = (acc[category] || 0) + (account.balance || 0);
+        return acc;
+    }, {} as Record<string, number>);
+
+    const chartData = Object.entries(categoryDataMap)
+        .map(([name, value]) => ({ name, value }))
+        .sort((a, b) => b.value - a.value);
+
+    const totalAssets = chartData.reduce((sum, item) => sum + item.value, 0);
+
+    const formatCurrency = (val: number) => new Intl.NumberFormat('en-GB', {
+        style: 'currency',
+        currency: 'GBP',
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2
+    }).format(val);
+
+    const formatPercentage = (val: number) => ((val / totalAssets) * 100).toFixed(1) + '%';
+
+    return (
+        <AppLayout
+            header={
+                <Header
+                    title="Asset Composition"
+                    subtitle="Portfolio Breakdown"
+                    leftElement={
+                        <div className="w-10 h-10 rounded-full bg-primary/20 flex items-center justify-center text-primary">
+                            <Icon name="pie_chart" className="text-2xl" />
+                        </div>
+                    }
+                />
+            }
+        >
+            <div className="p-4 space-y-6">
+                {accounts.length === 0 ? (
+                    <div className="text-center py-12 bg-white dark:bg-surface-dark rounded-2xl shadow-sm border border-slate-100 dark:border-[#283933]">
+                        <div className="w-16 h-16 bg-slate-100 dark:bg-black/30 rounded-full flex items-center justify-center mx-auto mb-4 text-slate-400 dark:text-slate-500">
+                            <Icon name="account_balance_wallet" className="text-3xl" />
+                        </div>
+                        <h3 className="text-lg font-medium text-slate-900 dark:text-white mb-2">No Assets Found</h3>
+                        <p className="text-slate-500 dark:text-slate-400 mb-6 max-w-sm mx-auto">
+                            Add some accounts to see your asset composition breakdown.
+                        </p>
+                    </div>
+                ) : (
+                    <>
+                        <div className="bg-white dark:bg-surface-dark rounded-2xl p-6 shadow-sm border border-slate-100 dark:border-[#283933]">
+                            <h2 className="text-lg font-bold text-slate-900 dark:text-white mb-4">Allocation by Category</h2>
+                            <div className="h-[300px] w-full">
+                                <ResponsiveContainer width="100%" height="100%">
+                                    <PieChart>
+                                        <Pie
+                                            data={chartData}
+                                            cx="50%"
+                                            cy="50%"
+                                            innerRadius={60}
+                                            outerRadius={80}
+                                            paddingAngle={5}
+                                            dataKey="value"
+                                        >
+                                            {chartData.map((_entry, index) => (
+                                                <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
+                                            ))}
+                                        </Pie>
+                                        <Tooltip
+                                            formatter={(value: number) => [formatCurrency(value), 'Value']}
+                                            contentStyle={{
+                                                backgroundColor: 'rgba(255, 255, 255, 0.96)',
+                                                borderRadius: '12px',
+                                                border: 'none',
+                                                boxShadow: '0 4px 12px rgba(0,0,0,0.1)',
+                                                color: '#1e293b'
+                                            }}
+                                        />
+                                        <Legend />
+                                    </PieChart>
+                                </ResponsiveContainer>
+                            </div>
+                            <div className="mt-4 text-center">
+                                <p className="text-sm text-slate-500 dark:text-slate-400">Total Net Worth</p>
+                                <p className="text-3xl font-bold text-slate-900 dark:text-white">{formatCurrency(totalAssets)}</p>
+                            </div>
+                        </div>
+
+                        <div className="space-y-3">
+                            <h2 className="text-lg font-bold text-slate-900 dark:text-white px-1">Detailed Breakdown</h2>
+                            {chartData.map((item, index) => (
+                                <div
+                                    key={item.name}
+                                    className="bg-white dark:bg-surface-dark rounded-xl p-4 shadow-sm border border-slate-100 dark:border-[#283933] flex items-center justify-between"
+                                >
+                                    <div className="flex items-center gap-3">
+                                        <div
+                                            className="w-3 h-3 rounded-full"
+                                            style={{ backgroundColor: COLORS[index % COLORS.length] }}
+                                        />
+                                        <div>
+                                            <p className="font-semibold text-slate-900 dark:text-white">{item.name}</p>
+                                            <p className="text-xs text-slate-500 dark:text-slate-400">{formatPercentage(item.value)} of total</p>
+                                        </div>
+                                    </div>
+                                    <div className="text-right">
+                                        <p className="font-bold text-slate-900 dark:text-white">{formatCurrency(item.value)}</p>
+                                    </div>
+                                </div>
+                            ))}
+                        </div>
+                    </>
+                )}
+            </div>
+        </AppLayout>
+    );
+}


### PR DESCRIPTION
This PR adds a new "Asset Composition" feature to the application.

Key changes:
- **New Page**: `AssetCompositionPage` fetches account data from the local database, groups it by category, and displays it using a donut chart and a detailed breakdown list.
- **Navigation**: A new "Asset Composition" link has been added to the side menu for easy access.
- **Visuals**: Uses `recharts` for high-quality data visualization and follows the existing design system.

The feature was verified with automated unit tests and manual visual inspection via Playwright.

Fixes #260

---
*PR created automatically by Jules for task [3185701205053614222](https://jules.google.com/task/3185701205053614222) started by @John-Bell*