### PR TITLE
Fix TypeScript build error in AssetCompositionPage

### DIFF
--- a/src/pages/AssetCompositionPage.tsx
+++ b/src/pages/AssetCompositionPage.tsx
@@ -80,7 +80,7 @@ export function AssetCompositionPage() {
                                             ))}
                                         </Pie>
                                         <Tooltip
-                                            formatter={(value: number) => [formatCurrency(value), 'Value']}
+                                            formatter={(value: any) => [formatCurrency(Number(value) || 0), 'Value']}
                                             contentStyle={{
                                                 backgroundColor: 'rgba(255, 255, 255, 0.96)',
                                                 borderRadius: '12px',


### PR DESCRIPTION
This change fixes a TypeScript error (TS2322) in src/pages/AssetCompositionPage.tsx where the Recharts Tooltip formatter was incorrectly typed. The value parameter is now safely converted to a number, satisfying the latest Recharts type definitions and preventing build failures.

Fixes #262

---
*PR created automatically by Jules for task [6541238501181924338](https://jules.google.com/task/6541238501181924338) started by @John-Bell*