### PR TITLE
Property Sale Handling and Projections

### DIFF
--- a/src/hooks/usePropertyForm.ts
+++ b/src/hooks/usePropertyForm.ts
@@ -7,6 +7,8 @@ export function usePropertyForm(id?: string) {
         name: string;
         expectedMonthlyIncome?: number;
         annualGrowthRate?: number;
+        estimatedNetCashOnSale?: number;
+        estimatedSaleDate?: string;
     }>({
         name: '',
     });
@@ -27,6 +29,8 @@ export function usePropertyForm(id?: string) {
                 name: property.name,
                 expectedMonthlyIncome: property.expectedMonthlyIncome,
                 annualGrowthRate: property.annualGrowthRate,
+                estimatedNetCashOnSale: property.estimatedNetCashOnSale,
+                estimatedSaleDate: property.estimatedSaleDate ? new Date(property.estimatedSaleDate).toISOString().split('T')[0] : undefined,
             });
         }
     }, [property]);
@@ -40,6 +44,8 @@ export function usePropertyForm(id?: string) {
             name: formData.name,
             expectedMonthlyIncome: formData.expectedMonthlyIncome ? Number(formData.expectedMonthlyIncome) : undefined,
             annualGrowthRate: formData.annualGrowthRate ? Number(formData.annualGrowthRate) : undefined,
+            estimatedNetCashOnSale: formData.estimatedNetCashOnSale ? Number(formData.estimatedNetCashOnSale) : undefined,
+            estimatedSaleDate: formData.estimatedSaleDate ? new Date(formData.estimatedSaleDate).getTime() : undefined,
             updatedAt: Date.now(),
         };
 

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -167,6 +167,8 @@ export interface Property {
     updatedAt?: number;
     expectedMonthlyIncome?: number;
     annualGrowthRate?: number;
+    estimatedNetCashOnSale?: number;
+    estimatedSaleDate?: number;
 }
 
 export interface PropertyExpense {
@@ -397,6 +399,26 @@ db.version(11).stores({
     });
 });
 
+db.version(12).stores({
+    profile: '&id',
+    accounts: '&id, ownerId, name, category, importId, updatedAt',
+    incomes: '&id, ownerId, name, frequency, type, taxCategory, updatedAt',
+    scenarios: '&id, name, updatedAt',
+    settings: '&id',
+    monthlyArchives: '&id, month, year, updatedAt',
+    notifications: '&id, date, read, updatedAt',
+    taxRules: '&id, updatedAt',
+    budgets: '&id, accountId, name, importId, updatedAt',
+    transactions: '&id, date, type, budgetId, accountId, importId, updatedAt',
+    paymentMappings: '&id, paymentName, *budgetIds, updatedAt',
+    interestAccruals: '&id, accountId, date, updatedAt',
+    properties: '&id, name, updatedAt',
+    propertyExpenses: '&id, propertyId, date, updatedAt',
+    propertyIncomes: '&id, propertyId, date, updatedAt',
+    propertyOwnership: '&id, propertyId, startDate, updatedAt',
+    deletedRows: '&id, tableName, deletedAt'
+});
+
 db.version(13).stores({
     profile: '&id',
     accounts: '&id, ownerId, name, category, importId, updatedAt',
@@ -437,7 +459,7 @@ db.version(14).stores({
     deletedRows: '&id, tableName, deletedAt'
 });
 
-db.version(12).stores({
+db.version(15).stores({
     profile: '&id',
     accounts: '&id, ownerId, name, category, importId, updatedAt',
     incomes: '&id, ownerId, name, frequency, type, taxCategory, updatedAt',
@@ -457,7 +479,7 @@ db.version(12).stores({
     deletedRows: '&id, tableName, deletedAt'
 });
 
-db.version(15).stores({
+db.version(16).stores({
     profile: '&id',
     accounts: '&id, ownerId, name, category, importId, updatedAt',
     incomes: '&id, ownerId, name, frequency, type, taxCategory, updatedAt',
@@ -581,6 +603,8 @@ export const getSanitizedDbData = async (): Promise<Record<string, any[]>> => {
             ...p,
             expectedMonthlyIncome: p.expectedMonthlyIncome !== undefined ? Number(p.expectedMonthlyIncome) : undefined,
             annualGrowthRate: p.annualGrowthRate !== undefined ? Number(p.annualGrowthRate) : undefined,
+            estimatedNetCashOnSale: p.estimatedNetCashOnSale !== undefined ? Number(p.estimatedNetCashOnSale) : undefined,
+            estimatedSaleDate: p.estimatedSaleDate !== undefined ? Number(p.estimatedSaleDate) : undefined,
         }));
     }
 

--- a/src/pages/AddPropertyPage.tsx
+++ b/src/pages/AddPropertyPage.tsx
@@ -73,6 +73,35 @@ export function AddPropertyPage() {
                                 />
                             </div>
                         </div>
+
+                        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                            <div>
+                                <label htmlFor="estimatedSaleDate" className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
+                                    Estimated Sale Date
+                                </label>
+                                <input
+                                    id="estimatedSaleDate"
+                                    type="date"
+                                    value={formData.estimatedSaleDate || ''}
+                                    onChange={(e) => setFormData(prev => ({ ...prev, estimatedSaleDate: e.target.value }))}
+                                    className="w-full px-4 py-3 rounded-xl border border-slate-200 dark:border-[#283933] bg-white dark:bg-black/20 text-slate-900 dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent transition-all"
+                                />
+                            </div>
+                            <div>
+                                <label htmlFor="estimatedNetCashOnSale" className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
+                                    Est. Net Cash on Sale (£)
+                                </label>
+                                <input
+                                    id="estimatedNetCashOnSale"
+                                    type="number"
+                                    step="1"
+                                    value={formData.estimatedNetCashOnSale || ''}
+                                    onChange={(e) => setFormData(prev => ({ ...prev, estimatedNetCashOnSale: e.target.value ? parseFloat(e.target.value) : undefined }))}
+                                    placeholder="0"
+                                    className="w-full px-4 py-3 rounded-xl border border-slate-200 dark:border-[#283933] bg-white dark:bg-black/20 text-slate-900 dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent transition-all"
+                                />
+                            </div>
+                        </div>
                     </div>
 
                     <div className="pt-6 border-t border-slate-100 dark:border-[#283933] flex justify-end gap-3">

--- a/src/pages/EditPropertyPage.tsx
+++ b/src/pages/EditPropertyPage.tsx
@@ -93,6 +93,35 @@ export function EditPropertyPage() {
                                 />
                             </div>
                         </div>
+
+                        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                            <div>
+                                <label htmlFor="estimatedSaleDate" className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
+                                    Estimated Sale Date
+                                </label>
+                                <input
+                                    id="estimatedSaleDate"
+                                    type="date"
+                                    value={formData.estimatedSaleDate || ''}
+                                    onChange={(e) => setFormData(prev => ({ ...prev, estimatedSaleDate: e.target.value }))}
+                                    className="w-full px-4 py-3 rounded-xl border border-slate-200 dark:border-[#283933] bg-white dark:bg-black/20 text-slate-900 dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent transition-all"
+                                />
+                            </div>
+                            <div>
+                                <label htmlFor="estimatedNetCashOnSale" className="block text-sm font-medium text-slate-700 dark:text-slate-300 mb-2">
+                                    Est. Net Cash on Sale (£)
+                                </label>
+                                <input
+                                    id="estimatedNetCashOnSale"
+                                    type="number"
+                                    step="1"
+                                    value={formData.estimatedNetCashOnSale || ''}
+                                    onChange={(e) => setFormData(prev => ({ ...prev, estimatedNetCashOnSale: e.target.value ? parseFloat(e.target.value) : undefined }))}
+                                    placeholder="0"
+                                    className="w-full px-4 py-3 rounded-xl border border-slate-200 dark:border-[#283933] bg-white dark:bg-black/20 text-slate-900 dark:text-white focus:ring-2 focus:ring-primary focus:border-transparent transition-all"
+                                />
+                            </div>
+                        </div>
                     </div>
 
                     <div className="pt-6 border-t border-slate-100 dark:border-[#283933] flex justify-between gap-3">

--- a/src/pages/PropertiesPage.tsx
+++ b/src/pages/PropertiesPage.tsx
@@ -123,6 +123,22 @@ export function PropertiesPage() {
                                             </p>
                                         </div>
                                     </div>
+
+                                    {(property.estimatedSaleDate || property.estimatedNetCashOnSale) && (
+                                        <div className="mt-4 pt-4 border-t border-slate-100 dark:border-[#283933] space-y-2">
+                                            <p className="text-xs font-bold text-slate-400 dark:text-slate-500 uppercase tracking-wider">Estimated Sale</p>
+                                            <div className="flex justify-between items-center">
+                                                <div className="flex items-center gap-2 text-slate-600 dark:text-slate-300">
+                                                    <Icon name="calendar_today" className="text-sm" />
+                                                    <span className="text-sm">{property.estimatedSaleDate ? new Date(property.estimatedSaleDate).toLocaleDateString('en-GB', { month: 'short', year: 'numeric' }) : 'Not set'}</span>
+                                                </div>
+                                                <div className="flex items-center gap-2 text-indigo-600 dark:text-indigo-400 font-semibold">
+                                                    <Icon name="payments" className="text-sm" />
+                                                    <span className="text-sm">{property.estimatedNetCashOnSale ? Intl.NumberFormat('en-GB', { style: 'currency', currency: 'GBP', maximumFractionDigits: 0 }).format(property.estimatedNetCashOnSale) : '£0'}</span>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    )}
                                 </div>
 
                                 <div className="mt-6 flex flex-wrap justify-end gap-2">

--- a/src/utils/projectionEngine.test.ts
+++ b/src/utils/projectionEngine.test.ts
@@ -170,4 +170,52 @@ describe('calculateLifetimeProjection', () => {
       expect(r.liquidAssets).toBeGreaterThanOrEqual(0);
     });
   });
+
+  it('TEST CASE 5: Property Sale - Income Termination and Cash Injection', () => {
+    // Sale on July 1st, 2026 (approx 50% through the year)
+    const saleDate = new Date('2026-07-01T00:00:00.000Z').getTime();
+
+    const input: ProjectionEngineInput = {
+      ...baseInput,
+      currentBalances: 100000,
+      properties: [
+        {
+          id: 'prop-1',
+          name: 'Rental Prop',
+          expectedMonthlyIncome: 1000, // £12k / year
+          annualGrowthRate: 0,
+          estimatedSaleDate: saleDate,
+          estimatedNetCashOnSale: 200000,
+          updatedAt: Date.now(),
+        },
+      ],
+      propertyOwnership: [
+        {
+          id: 'own-1',
+          propertyId: 'prop-1',
+          startDate: 0,
+          person1Percent: 50,
+          person2Percent: 50,
+          updatedAt: Date.now(),
+        },
+      ],
+    };
+
+    const results = calculateLifetimeProjection(input);
+
+    // Year 0 (2025): Full rental income (£12,000)
+    const year0Delta = results[0].liquidAssets - input.currentBalances;
+    expect(year0Delta).toBeCloseTo(12000, 2);
+
+    // Year 1 (2026): Pro-rated rent (~£6,000) + Cash Injection (£200,000)
+    // Rent is for Jan-June inclusive (approx 181 days out of 365)
+    // 181/365 * 12000 = 5950.68
+    const year1Delta = results[1].liquidAssets - results[0].liquidAssets;
+    expect(year1Delta).toBeGreaterThan(205900);
+    expect(year1Delta).toBeLessThan(206100);
+
+    // Year 2 (2027): No rental income, no more cash injection
+    const year2Delta = results[2].liquidAssets - results[1].liquidAssets;
+    expect(year2Delta).toBe(0);
+  });
 });

--- a/src/utils/projectionEngine.ts
+++ b/src/utils/projectionEngine.ts
@@ -99,15 +99,37 @@ export function calculateLifetimeProjection(input: ProjectionEngineInput): Proje
 
     let p1RentalGrossForYear = 0;
     let p2RentalGrossForYear = 0;
+    let totalCashInjectionsForYear = 0;
 
     for (const property of input.properties) {
+      // Step 0: Check for sale in this year
+      const saleTs = property.estimatedSaleDate;
+      const hasSaleDate = saleTs !== undefined;
+      const isSoldBeforeThisYear = hasSaleDate && saleTs < yearStartTs;
+      const isSoldDuringThisYear = hasSaleDate && saleTs >= yearStartTs && saleTs <= yearEndTs;
+
+      if (isSoldBeforeThisYear) {
+        // No rental income if sold in a previous year
+        continue;
+      }
+
       // Step A: Escalate Expected Rent
       const baseMonthly = property.expectedMonthlyIncome ?? 0;
       const annualBaseRent = baseMonthly * 12;
       const growthRate = property.annualGrowthRate ?? 0;
-      const escalatedGrossRent = annualBaseRent * Math.pow(1 + growthRate / 100, yearIndex);
+      let escalatedGrossRent = annualBaseRent * Math.pow(1 + growthRate / 100, yearIndex);
 
-      // Step B: Find active ownership split
+      // Step B: Pro-rate rent if sold this year
+      if (isSoldDuringThisYear && saleTs !== undefined) {
+        const activeMs = saleTs - yearStartTs;
+        const fraction = Math.max(0, activeMs / yearTotalMs);
+        escalatedGrossRent *= fraction;
+
+        // Inject cash on sale
+        totalCashInjectionsForYear += property.estimatedNetCashOnSale ?? 0;
+      }
+
+      // Step C: Find active ownership split
       const relevantOwnerships = input.propertyOwnership
         .filter(o => o.propertyId === property.id && o.startDate <= yearEndTs)
         .sort((a, b) => b.startDate - a.startDate);
@@ -116,7 +138,7 @@ export function calculateLifetimeProjection(input: ProjectionEngineInput): Proje
         ? relevantOwnerships[0]
         : { person1Percent: 50, person2Percent: 50 };
 
-      // Step C: Apportion to loop tracking variables
+      // Step D: Apportion to loop tracking variables
       p1RentalGrossForYear += escalatedGrossRent * (activeSplit.person1Percent / 100);
       p2RentalGrossForYear += escalatedGrossRent * (activeSplit.person2Percent / 100);
     }
@@ -157,8 +179,8 @@ export function calculateLifetimeProjection(input: ProjectionEngineInput): Proje
     const totalInflows = (p1Salary + p1Pension + p1Dividends + p2Salary + p2Pension + p2Dividends) + p1RentalGrossForYear + p2RentalGrossForYear;
     const netCashFlow = totalInflows - totalBudgetsForYear - totalTaxForYear;
 
-    if (trackingLiquidAssets > 0) {
-      trackingLiquidAssets = (trackingLiquidAssets + netCashFlow) * (1 + input.realGrowthRate / 100);
+    if (trackingLiquidAssets > 0 || totalCashInjectionsForYear > 0) {
+      trackingLiquidAssets = (trackingLiquidAssets + netCashFlow + totalCashInjectionsForYear) * (1 + input.realGrowthRate / 100);
     } else {
       trackingLiquidAssets = 0;
     }


### PR DESCRIPTION
This PR implements the ability to handle property sales within the application. 

Key changes include:
1.  **Data Model**: Added optional `estimatedNetCashOnSale` (number) and `estimatedSaleDate` (timestamp) fields to the `Property` interface in `src/lib/db.ts`.
2.  **Form Handling**: Updated the `usePropertyForm` hook and the property creation/edit screens (`AddPropertyPage.tsx`, `EditPropertyPage.tsx`) to capture these new fields.
3.  **UI Updates**: The `PropertiesPage.tsx` now displays the estimated sale date and net cash injection for properties that have these values set.
4.  **Projection Engine**: Enhanced the `calculateLifetimeProjection` utility in `src/utils/projectionEngine.ts` to:
    -   Automatically pro-rate rental income in the calendar year of sale.
    -   Terminate rental income for all subsequent years.
    -   Inject the estimated net cash into the user's liquid assets during the year of sale.
5.  **Testing**: Added a dedicated test case in `src/utils/projectionEngine.test.ts` to verify the accuracy of the sale simulation.
6.  **Database**: Incremented the Dexie database version to 16 to accommodate the schema update.

Fixes #264

---
*PR created automatically by Jules for task [8697357125295266344](https://jules.google.com/task/8697357125295266344) started by @John-Bell*