### PR TITLE
Add asset pot breakdown and drawdown strategies to projection engine

### DIFF
--- a/src/utils/projectionEngine.test.ts
+++ b/src/utils/projectionEngine.test.ts
@@ -218,4 +218,89 @@ describe('calculateLifetimeProjection', () => {
     const year2Delta = results[2].liquidAssets - results[1].liquidAssets;
     expect(year2Delta).toBe(0);
   });
+
+  it('TEST CASE 6: Asset Pot Breakdown and Drawdown Strategy (taxable_first)', () => {
+    const input: ProjectionEngineInput = {
+      ...baseInput,
+      currentBalances: 300000,
+      assetPots: {
+        taxable: 100000,
+        taxFree: 100000,
+        pensions: 100000,
+      },
+      drawdownStrategy: 'taxable_first',
+      realGrowthRate: 0,
+      budgets: [
+        {
+          id: 'budg-1',
+          accountId: 'acc-1',
+          name: 'Budget',
+          amount: 50000,
+          frequency: 'annually',
+          updatedAt: Date.now(),
+        },
+      ],
+    };
+
+    const results = calculateLifetimeProjection(input);
+
+    // Year 0 (2025): 300k - 50k = 250k total.
+    // strategy: taxable_first. Taxable should be 100k - 50k = 50k. others 100k.
+    expect(results[0].liquidAssets).toBe(250000);
+    expect(results[0].potBalances.taxable).toBe(50000);
+    expect(results[0].potBalances.taxFree).toBe(100000);
+    expect(results[0].potBalances.pensions).toBe(100000);
+    expect(results[0].potBalances.total).toBe(250000);
+
+    // Year 1 (2026): 250k - 50k = 200k total.
+    // Taxable was 50k. 50k - 50k = 0k. others 100k.
+    expect(results[1].liquidAssets).toBe(200000);
+    expect(results[1].potBalances.taxable).toBe(0);
+    expect(results[1].potBalances.taxFree).toBe(100000);
+    expect(results[1].potBalances.pensions).toBe(100000);
+
+    // Year 2 (2027): 200k - 50k = 150k total.
+    // Taxable was 0k. Deficit 50k comes from taxFree (next in order).
+    // taxFree: 100k - 50k = 50k. pensions: 100k.
+    expect(results[2].liquidAssets).toBe(150000);
+    expect(results[2].potBalances.taxable).toBe(0);
+    expect(results[2].potBalances.taxFree).toBe(50000);
+    expect(results[2].potBalances.pensions).toBe(100000);
+  });
+
+  it('TEST CASE 7: Proportional Drawdown Strategy', () => {
+    const input: ProjectionEngineInput = {
+      ...baseInput,
+      currentBalances: 300000,
+      assetPots: {
+        taxable: 150000,
+        taxFree: 50000,
+        pensions: 100000,
+      },
+      drawdownStrategy: 'proportional',
+      realGrowthRate: 0,
+      budgets: [
+        {
+          id: 'budg-1',
+          accountId: 'acc-1',
+          name: 'Budget',
+          amount: 30000,
+          frequency: 'annually',
+          updatedAt: Date.now(),
+        },
+      ],
+    };
+
+    const results = calculateLifetimeProjection(input);
+
+    // Total = 300k. Deficit = 30k (10%).
+    // Each pot should be reduced by 10%.
+    // taxable: 150k - 15k = 135k
+    // taxFree: 50k - 5k = 45k
+    // pensions: 100k - 10k = 90k
+    expect(results[0].liquidAssets).toBe(270000);
+    expect(results[0].potBalances.taxable).toBe(135000);
+    expect(results[0].potBalances.taxFree).toBe(45000);
+    expect(results[0].potBalances.pensions).toBe(90000);
+  });
 });

--- a/src/utils/projectionEngine.ts
+++ b/src/utils/projectionEngine.ts
@@ -2,8 +2,16 @@ import type { Income, Budget, Property, PropertyOwnership } from '../lib/db';
 import { TaxCalculationService } from '../services/TaxCalculationService';
 import type { TaxRulesByYear } from '../constants/taxConstants';
 
+export type DrawdownStrategy = 'taxable_first' | 'tax_free_first' | 'pensions_first' | 'proportional';
+
 export interface ProjectionEngineInput {
   currentBalances: number; // Sum of active balances across liquid pots
+  assetPots?: {
+    taxable: number;
+    taxFree: number;
+    pensions: number;
+  };
+  drawdownStrategy?: DrawdownStrategy;
   realGrowthRate: number;  // App global growth asset rate (e.g., 2.38)
   profile: {
     partner1Dob: number;   // Epoch timestamp ms
@@ -22,6 +30,12 @@ export interface ProjectionYearResult {
   ageP1: number;
   ageP2: number | null;
   liquidAssets: number;
+  potBalances: {
+    taxable: number;
+    taxFree: number;
+    pensions: number;
+    total: number;
+  };
   isRunwayBroken: boolean;
   milestones: string[];
   annualBudget: number;
@@ -48,7 +62,10 @@ export function calculateLifetimeProjection(input: ProjectionEngineInput): Proje
     currentAgeP2 = calculateAge(input.profile.partner2Dob, currentDate);
   }
 
-  let trackingLiquidAssets = input.currentBalances;
+  let trackingTaxable = input.assetPots?.taxable ?? input.currentBalances;
+  let trackingTaxFree = input.assetPots?.taxFree ?? 0;
+  let trackingPensions = input.assetPots?.pensions ?? 0;
+
   const results: ProjectionYearResult[] = [];
 
   let yearIndex = 0;
@@ -179,15 +196,72 @@ export function calculateLifetimeProjection(input: ProjectionEngineInput): Proje
     const totalInflows = (p1Salary + p1Pension + p1Dividends + p2Salary + p2Pension + p2Dividends) + p1RentalGrossForYear + p2RentalGrossForYear;
     const netCashFlow = totalInflows - totalBudgetsForYear - totalTaxForYear;
 
-    if (trackingLiquidAssets > 0 || totalCashInjectionsForYear > 0) {
-      trackingLiquidAssets = (trackingLiquidAssets + netCashFlow + totalCashInjectionsForYear) * (1 + input.realGrowthRate / 100);
+    const totalBefore = trackingTaxable + trackingTaxFree + trackingPensions;
+
+    if (totalBefore > 0 || totalCashInjectionsForYear > 0) {
+      let annualSurplus = netCashFlow + totalCashInjectionsForYear;
+
+      if (annualSurplus >= 0) {
+        trackingTaxable += annualSurplus;
+      } else {
+        let deficit = Math.abs(annualSurplus);
+        const strategy = input.drawdownStrategy || 'proportional';
+
+        if (strategy === 'proportional') {
+          const totalAtStartOfDeficit = trackingTaxable + trackingTaxFree + trackingPensions;
+          if (totalAtStartOfDeficit > 0) {
+            const ratioTaxable = trackingTaxable / totalAtStartOfDeficit;
+            const ratioTaxFree = trackingTaxFree / totalAtStartOfDeficit;
+            const ratioPensions = trackingPensions / totalAtStartOfDeficit;
+
+            trackingTaxable -= deficit * ratioTaxable;
+            trackingTaxFree -= deficit * ratioTaxFree;
+            trackingPensions -= deficit * ratioPensions;
+          }
+        } else {
+          const order: ('taxable' | 'taxFree' | 'pensions')[] =
+            strategy === 'taxable_first' ? ['taxable', 'taxFree', 'pensions'] :
+            strategy === 'tax_free_first' ? ['taxFree', 'taxable', 'pensions'] :
+            ['pensions', 'taxable', 'taxFree']; // pensions_first
+
+          for (const pot of order) {
+            if (deficit <= 0) break;
+            if (pot === 'taxable') {
+              const draw = Math.min(trackingTaxable, deficit);
+              trackingTaxable -= draw;
+              deficit -= draw;
+            } else if (pot === 'taxFree') {
+              const draw = Math.min(trackingTaxFree, deficit);
+              trackingTaxFree -= draw;
+              deficit -= draw;
+            } else if (pot === 'pensions') {
+              const draw = Math.min(trackingPensions, deficit);
+              trackingPensions -= draw;
+              deficit -= draw;
+            }
+          }
+        }
+      }
+
+      // Apply Growth
+      trackingTaxable *= (1 + input.realGrowthRate / 100);
+      trackingTaxFree *= (1 + input.realGrowthRate / 100);
+      trackingPensions *= (1 + input.realGrowthRate / 100);
     } else {
-      trackingLiquidAssets = 0;
+      trackingTaxable = 0;
+      trackingTaxFree = 0;
+      trackingPensions = 0;
     }
 
+    // Floor and handle runway
+    if (trackingTaxable < 0) trackingTaxable = 0;
+    if (trackingTaxFree < 0) trackingTaxFree = 0;
+    if (trackingPensions < 0) trackingPensions = 0;
+
+    const trackingTotalLiquidAssets = trackingTaxable + trackingTaxFree + trackingPensions;
+
     let isRunwayBroken = false;
-    if (trackingLiquidAssets <= 0) {
-      trackingLiquidAssets = 0;
+    if (trackingTotalLiquidAssets <= 0) {
       isRunwayBroken = true;
     }
 
@@ -196,7 +270,13 @@ export function calculateLifetimeProjection(input: ProjectionEngineInput): Proje
       calendarYear: runningCalendarYear,
       ageP1: currentAgeP1,
       ageP2: currentAgeP2,
-      liquidAssets: trackingLiquidAssets,
+      liquidAssets: trackingTotalLiquidAssets,
+      potBalances: {
+        taxable: trackingTaxable,
+        taxFree: trackingTaxFree,
+        pensions: trackingPensions,
+        total: trackingTotalLiquidAssets
+      },
       isRunwayBroken: isRunwayBroken,
       milestones: [],
       annualBudget: totalBudgetsForYear,


### PR DESCRIPTION
This PR updates the multi-decade projection engine to support a granular breakdown of liquid assets into three categories: taxable, tax-free, and pensions. 

Key changes:
- **Type Definitions**: Added `DrawdownStrategy` and updated `ProjectionEngineInput` and `ProjectionYearResult`.
- **Logic Updates**: The engine now tracks individual pots and applies a selected drawdown strategy when annual net cash flow is negative. Surpluses are added to the taxable pot.
- **Backward Compatibility**: Existing callers only providing `currentBalances` will have their total balance treated as the taxable pot. The `liquidAssets` output property is preserved and strictly synchronized with the sum of all pots.
- **Tests**: Added new test cases verifying ordered and proportional drawdown strategies.

Fixes #266

---
*PR created automatically by Jules for task [16808288387832549904](https://jules.google.com/task/16808288387832549904) started by @John-Bell*