### PR TITLE
Add Asset Burndown Page for Drawdown Strategy Optimization

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,6 +31,7 @@ import { AddPropertyOwnershipPage } from '@/pages/AddPropertyOwnershipPage';
 import { EditPropertyOwnershipPage } from '@/pages/EditPropertyOwnershipPage';
 import { SimulatorPage } from '@/pages/SimulatorPage';
 import { CashflowProjectionPage } from '@/pages/CashflowProjectionPage';
+import { AssetBurndownPage } from '@/pages/AssetBurndownPage';
 import { AssetCompositionPage } from '@/pages/AssetCompositionPage';
 import { useStore } from '@/store/useStore';
 import { remoteSyncService } from '@/services/remoteSyncService';
@@ -93,6 +94,7 @@ function AppRoutes() {
       <Route path="/property-ownerships/edit/:id" element={<EditPropertyOwnershipPage />} />
       <Route path="/simulator" element={<SimulatorPage />} />
       <Route path="/cashflow-projection" element={<CashflowProjectionPage />} />
+      <Route path="/asset-burndown" element={<AssetBurndownPage />} />
       <Route path="/asset-composition" element={<AssetCompositionPage />} />
       {/* Setup Routes */}
       <Route path="/setup" element={<SimplifiedAppSetupPage />} />

--- a/src/components/layout/SideMenu.tsx
+++ b/src/components/layout/SideMenu.tsx
@@ -87,6 +87,18 @@ export function SideMenu({ isOpen, onClose }: SideMenuProps) {
                     </button>
                     <button
                         type="button"
+                        onClick={() => handleNavigate('/asset-burndown')}
+                        className="flex items-center gap-4 w-full p-3 rounded-xl hover:bg-slate-100 dark:hover:bg-surface-dark transition-colors text-left cursor-pointer group"
+                    >
+                        <div className="w-10 h-10 rounded-full bg-slate-200 dark:bg-black/30 flex items-center justify-center text-slate-700 dark:text-slate-300 group-hover:text-primary transition-colors">
+                            <Icon name="bar_chart" className="text-xl" />
+                        </div>
+                        <span className="font-semibold text-slate-700 dark:text-slate-200 group-hover:text-slate-900 dark:group-hover:text-white transition-colors">
+                            Asset Burndown
+                        </span>
+                    </button>
+                    <button
+                        type="button"
                         onClick={() => handleNavigate('/asset-composition')}
                         className="flex items-center gap-4 w-full p-3 rounded-xl hover:bg-slate-100 dark:hover:bg-surface-dark transition-colors text-left cursor-pointer group"
                     >

--- a/src/components/scenarios/AssetBurndownChart.tsx
+++ b/src/components/scenarios/AssetBurndownChart.tsx
@@ -1,0 +1,204 @@
+import React, { useState } from 'react';
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+} from 'recharts';
+import { useLifetimeProjection } from '@/hooks/useLifetimeProjection';
+import type { DrawdownStrategy } from '@/utils/projectionEngine';
+
+/**
+ * AssetBurndownChart
+ * A touch-first mobile chart showing the breakdown of asset pots over time.
+ */
+interface TouchTooltipBridgeProps {
+  active?: boolean;
+  payload?: any[];
+  onPointUpdate: (point: any) => void;
+}
+
+const TouchTooltipBridge: React.FC<TouchTooltipBridgeProps> = ({ active, payload, onPointUpdate }) => {
+  React.useEffect(() => {
+    if (active && payload && payload.length > 0) {
+      onPointUpdate(payload[0].payload);
+    }
+  }, [active, payload, onPointUpdate]);
+
+  return null;
+};
+
+interface AssetBurndownChartProps {
+  drawdownStrategy?: DrawdownStrategy;
+}
+
+const AssetBurndownChart: React.FC<AssetBurndownChartProps> = ({ drawdownStrategy }) => {
+  const { data, isReady, p1Name, p2Name } = useLifetimeProjection(drawdownStrategy);
+  const [activePoint, setActivePoint] = useState<any>(null);
+
+  // Loading State
+  if (!isReady || !data || data.length === 0) {
+    return (
+      <div className="w-full h-[380px] bg-gray-50 animate-pulse rounded-xl" />
+    );
+  }
+
+  // Determine point to display: Active touch point or default to first point (Day-0)
+  const displayPoint = activePoint || data[0];
+
+  const formatCurrency = (value: number) =>
+    new Intl.NumberFormat('en-GB', {
+      style: 'currency',
+      currency: 'GBP',
+      maximumFractionDigits: 0,
+    }).format(value);
+
+  const formatYAxis = (v: number) => `£${v / 1000}k`;
+
+  // Custom X-Axis Tick
+  const CustomTick = (props: any) => {
+    const { x, y, payload } = props;
+    const point = data.find((d: any) => d.calendarYear === payload.value);
+    if (!point) return null;
+
+    return (
+      <g transform={`translate(${x},${y})`}>
+        <text
+          x={0}
+          y={0}
+          dy={12}
+          textAnchor="middle"
+          fill="#6B7280"
+          className="text-[10px] font-medium"
+        >
+          <tspan x="0" dy="1.2em">{point.ageP1}</tspan>
+          <tspan x="0" dy="1.2em">{point.ageP2}</tspan>
+        </text>
+      </g>
+    );
+  };
+
+  // Recharts 3.x Tooltip formatter fix (as per memory)
+  const tooltipFormatter = (value: any) => {
+    return formatCurrency(Number(value) || 0);
+  };
+
+  return (
+    <div className="w-full bg-white p-4 rounded-xl border border-gray-100 shadow-sm touch-pan-y select-none relative">
+      {/* TOUCH READOUT DATA HEADER PANEL */}
+      <div className="mb-4 pt-2">
+        <div className="flex items-baseline justify-between">
+          <div className="text-2xl font-bold text-gray-900 dark:text-white tracking-tight">
+            {formatCurrency(displayPoint.liquidAssets)}
+          </div>
+          <div className="text-xs font-semibold px-2 py-0.5 rounded bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-300">
+            {displayPoint.calendarYear}
+          </div>
+        </div>
+
+        <div className="text-xs font-medium text-slate-500 dark:text-slate-400 mt-1">
+          {p1Name}: Age {displayPoint.ageP1} {p2Name ? `• ${p2Name}: Age ${displayPoint.ageP2}` : ''}
+        </div>
+
+        {/* Breakdown Row */}
+        <div className="grid grid-cols-3 gap-2 mt-3 pt-3 border-t border-dashed border-gray-100 dark:border-slate-800">
+          <div>
+            <span className="block text-[10px] uppercase font-bold text-indigo-600 tracking-wider">Taxable</span>
+            <span className="text-sm font-semibold text-slate-700 dark:text-slate-200">
+              {formatCurrency(displayPoint.potBalances.taxable)}
+            </span>
+          </div>
+          <div>
+            <span className="block text-[10px] uppercase font-bold text-emerald-600 tracking-wider">Tax-Free</span>
+            <span className="text-sm font-semibold text-slate-700 dark:text-slate-200">
+              {formatCurrency(displayPoint.potBalances.taxFree)}
+            </span>
+          </div>
+          <div>
+            <span className="block text-[10px] uppercase font-bold text-amber-600 tracking-wider">Pensions</span>
+            <span className="text-sm font-semibold text-slate-700 dark:text-slate-200">
+              {formatCurrency(displayPoint.potBalances.pensions)}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      {/* THE RECHARTS GRAPH CANVAS */}
+      <div className="w-full h-[280px]">
+        <ResponsiveContainer width="100%" height="100%">
+          <AreaChart
+            data={data}
+            margin={{ top: 10, right: 10, left: -20, bottom: 20 }}
+          >
+            <CartesianGrid
+              vertical={false}
+              strokeDasharray="3 3"
+              stroke="#E5E7EB"
+            />
+
+            <XAxis
+              dataKey="calendarYear"
+              axisLine={false}
+              tickLine={false}
+              interval={Math.floor(data.length / 6)}
+              tick={<CustomTick />}
+            />
+
+            <YAxis
+              width={42}
+              axisLine={false}
+              tickLine={false}
+              fontSize={10}
+              tick={{ fill: '#9CA3AF' }}
+              tickFormatter={formatYAxis}
+            />
+
+            <Tooltip
+              cursor={{ stroke: '#4B0082', strokeWidth: 1, strokeDasharray: '4 4' }}
+              content={<TouchTooltipBridge onPointUpdate={setActivePoint} />}
+              formatter={tooltipFormatter}
+            />
+
+            <Area
+              type="monotone"
+              dataKey="potBalances.pensions"
+              stackId="1"
+              stroke="#F59E0B"
+              fill="#F59E0B"
+              fillOpacity={0.6}
+              animationDuration={1000}
+            />
+            <Area
+              type="monotone"
+              dataKey="potBalances.taxFree"
+              stackId="1"
+              stroke="#10B981"
+              fill="#10B981"
+              fillOpacity={0.6}
+              animationDuration={1000}
+            />
+            <Area
+              type="monotone"
+              dataKey="potBalances.taxable"
+              stackId="1"
+              stroke="#4B0082"
+              fill="#4B0082"
+              fillOpacity={0.6}
+              animationDuration={1000}
+            />
+          </AreaChart>
+        </ResponsiveContainer>
+      </div>
+
+      <div className="flex flex-col gap-1 mt-2 text-[10px] text-gray-400 absolute bottom-6 left-4">
+        <span>{p1Name}</span>
+        <span>{p2Name}</span>
+      </div>
+    </div>
+  );
+};
+
+export default AssetBurndownChart;

--- a/src/hooks/useLifetimeProjection.ts
+++ b/src/hooks/useLifetimeProjection.ts
@@ -1,11 +1,11 @@
 import { useMemo } from 'react';
 import { useLiveQuery } from 'dexie-react-hooks';
 import { db } from '@/lib/db';
-import { calculateLifetimeProjection } from '@/utils/projectionEngine';
+import { calculateLifetimeProjection, type DrawdownStrategy } from '@/utils/projectionEngine';
 import type { TaxRulesByYear } from '@/constants/taxConstants';
 import type { ProjectionYearResult } from '@/utils/projectionEngine';
 
-export function useLifetimeProjection() {
+export function useLifetimeProjection(drawdownStrategy?: DrawdownStrategy) {
   const dbProfile = useLiveQuery(() => db.profile.toArray());
   const dbAccounts = useLiveQuery(() => db.accounts.toArray());
   const dbIncomes = useLiveQuery(() => db.incomes.toArray());
@@ -48,6 +48,18 @@ export function useLifetimeProjection() {
     const totalLiquidBalances = dbAccounts
       .filter((account) => liquidCategories.includes(account.category))
       .reduce((sum, account) => sum + account.balance, 0);
+
+    const assetPots = {
+      taxable: dbAccounts
+        .filter(a => liquidCategories.includes(a.category) && !['Cash ISA', 'Shares ISA', 'Premium Bonds', 'DC Pension'].includes(a.category))
+        .reduce((sum, a) => sum + a.balance, 0),
+      taxFree: dbAccounts
+        .filter(a => ['Cash ISA', 'Shares ISA', 'Premium Bonds'].includes(a.category))
+        .reduce((sum, a) => sum + a.balance, 0),
+      pensions: dbAccounts
+        .filter(a => a.category === 'DC Pension')
+        .reduce((sum, a) => sum + a.balance, 0)
+    };
 
     // Reduce tax rules into a keyed map dictionary
     const reducedTaxRulesMap: TaxRulesByYear = dbTaxRules.reduce((acc, rule) => {
@@ -93,6 +105,8 @@ export function useLifetimeProjection() {
     // Execute Engine Matrix
     const projectionData = calculateLifetimeProjection({
       currentBalances: totalLiquidBalances,
+      assetPots,
+      drawdownStrategy,
       realGrowthRate: growthRate,
       profile: {
         partner1Dob: activeProfile.partner1Dob as number,
@@ -120,6 +134,7 @@ export function useLifetimeProjection() {
     dbProperties,
     dbPropertyOwnership,
     dbTaxRules,
-    dbSettings
+    dbSettings,
+    drawdownStrategy
   ]);
 }

--- a/src/pages/AssetBurndownPage.tsx
+++ b/src/pages/AssetBurndownPage.tsx
@@ -1,0 +1,132 @@
+import { useState } from 'react';
+import { AppLayout } from '../components/layout/AppLayout';
+import { Header } from '../components/layout/Header';
+import { Icon } from '../components/ui/Icon';
+import AssetBurndownChart from '../components/scenarios/AssetBurndownChart';
+import { FinancialImpactCard } from '../components/scenarios/FinancialImpactCard';
+import { useLifetimeProjection } from '../hooks/useLifetimeProjection';
+import type { DrawdownStrategy } from '../utils/projectionEngine';
+import { cn } from '@/lib/utils';
+
+export function AssetBurndownPage() {
+    const [strategy, setStrategy] = useState<DrawdownStrategy>('taxable_first');
+    const { data, isReady } = useLifetimeProjection(strategy);
+
+    const firstPoint = isReady && data.length > 0 ? data[0] : null;
+    const lastPoint = isReady && data.length > 0 ? data[data.length - 1] : null;
+
+    const formatCurrency = (val: number) => new Intl.NumberFormat('en-GB', {
+        style: 'currency',
+        currency: 'GBP',
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 0
+    }).format(val);
+
+    const strategies: { id: DrawdownStrategy; label: string; icon: string }[] = [
+        { id: 'taxable_first', label: 'Taxable First', icon: 'account_balance' },
+        { id: 'tax_free_first', label: 'Tax-Free First', icon: 'savings' },
+        { id: 'pensions_first', label: 'Pensions First', icon: 'history_edu' },
+        { id: 'proportional', label: 'Proportional', icon: 'balance' },
+    ];
+
+    return (
+        <AppLayout
+            header={
+                <Header
+                    title="Asset Burndown"
+                    subtitle="Drawdown Strategy Optimization"
+                    leftElement={
+                        <div className="w-10 h-10 rounded-full bg-primary/20 flex items-center justify-center text-primary">
+                            <Icon name="bar_chart" className="text-2xl" />
+                        </div>
+                    }
+                />
+            }
+        >
+            <div className="mx-auto p-4 max-w-7xl">
+                <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+                    <div className="lg:col-span-2 space-y-6">
+                        {/* Strategy Selector */}
+                        <div className="bg-white dark:bg-slate-900/50 p-1.5 rounded-xl border border-gray-100 dark:border-slate-800 flex flex-wrap gap-1">
+                            {strategies.map((s) => (
+                                <button
+                                    key={s.id}
+                                    onClick={() => setStrategy(s.id)}
+                                    className={cn(
+                                        "flex-1 flex items-center justify-center gap-2 px-3 py-2.5 rounded-lg text-sm font-semibold transition-all cursor-pointer",
+                                        strategy === s.id
+                                            ? "bg-primary text-white shadow-md shadow-primary/20"
+                                            : "text-slate-500 hover:bg-slate-100 dark:hover:bg-slate-800"
+                                    )}
+                                >
+                                    <Icon name={s.icon} className="text-lg" />
+                                    <span className="hidden sm:inline">{s.label}</span>
+                                    <span className="sm:hidden">{s.label.split(' ')[0]}</span>
+                                </button>
+                            ))}
+                        </div>
+
+                        <div className="space-y-4">
+                            <div className="flex items-center justify-between px-1">
+                                <h2 className="text-sm font-bold uppercase tracking-widest text-slate-500 dark:text-primary/40">Burndown Analysis</h2>
+                            </div>
+                            <AssetBurndownChart drawdownStrategy={strategy} />
+                        </div>
+
+                        {/* Strategy Description */}
+                        <div className="bg-blue-50 dark:bg-blue-900/20 p-4 rounded-xl border border-blue-100 dark:border-blue-900/30">
+                            <div className="flex gap-3">
+                                <Icon name="info" className="text-blue-600 dark:text-blue-400 mt-0.5" />
+                                <div className="text-sm text-blue-800 dark:text-blue-200 leading-relaxed">
+                                    {strategy === 'taxable_first' && "Withdraws from taxable accounts first, preserving tax-free and pension growth as long as possible."}
+                                    {strategy === 'tax_free_first' && "Uses ISAs and other tax-free assets first. Generally less efficient for long-term tax planning."}
+                                    {strategy === 'pensions_first' && "Draws from pension pots first. Useful if you expect higher tax rates in later life."}
+                                    {strategy === 'proportional' && "Withdraws from all pots relative to their current size, maintaining the same asset allocation over time."}
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+
+                    <div className="space-y-6">
+                        <div className="flex items-center justify-between px-1">
+                            <h2 className="text-sm font-bold uppercase tracking-widest text-slate-500 dark:text-primary/40">Terminal Pot Values</h2>
+                        </div>
+
+                        <FinancialImpactCard
+                            title="Taxable Assets"
+                            icon="account_balance"
+                            iconBg="bg-indigo-100 dark:bg-indigo-900/30"
+                            iconColor="text-indigo-600 dark:text-indigo-400"
+                            badgeText="Terminal"
+                            badgeTrend={lastPoint && lastPoint.potBalances.taxable > (firstPoint?.potBalances.taxable || 0) ? 'up' : 'down'}
+                            currentValue={formatCurrency(firstPoint?.potBalances.taxable || 0)}
+                            projectedValue={formatCurrency(lastPoint?.potBalances.taxable || 0)}
+                        />
+
+                        <FinancialImpactCard
+                            title="Tax-Free Assets"
+                            icon="savings"
+                            iconBg="bg-emerald-100 dark:bg-emerald-900/30"
+                            iconColor="text-emerald-600 dark:text-emerald-400"
+                            badgeText="Terminal"
+                            badgeTrend={lastPoint && lastPoint.potBalances.taxFree > (firstPoint?.potBalances.taxFree || 0) ? 'up' : 'down'}
+                            currentValue={formatCurrency(firstPoint?.potBalances.taxFree || 0)}
+                            projectedValue={formatCurrency(lastPoint?.potBalances.taxFree || 0)}
+                        />
+
+                        <FinancialImpactCard
+                            title="Pension Assets"
+                            icon="history_edu"
+                            iconBg="bg-amber-100 dark:bg-amber-900/30"
+                            iconColor="text-amber-600 dark:text-amber-400"
+                            badgeText="Terminal"
+                            badgeTrend={lastPoint && lastPoint.potBalances.pensions > (firstPoint?.potBalances.pensions || 0) ? 'up' : 'down'}
+                            currentValue={formatCurrency(firstPoint?.potBalances.pensions || 0)}
+                            projectedValue={formatCurrency(lastPoint?.potBalances.pensions || 0)}
+                        />
+                    </div>
+                </div>
+            </div>
+        </AppLayout>
+    );
+}


### PR DESCRIPTION
Implemented a new "Asset Burndown" page that allows users to visualize and optimize their drawdown strategy. The page features a stacked area chart showing the depletion of taxable, tax-free, and pension asset pots over time. Users can toggle between different drawdown strategies (Taxable First, Tax-Free First, Pensions First, and Proportional) to see the impact on their terminal wealth. The implementation leverages existing projection engine capabilities while maintaining the existing cashflow projection functionality.

Fixes #268

---
*PR created automatically by Jules for task [17009257665638345076](https://jules.google.com/task/17009257665638345076) started by @John-Bell*