### PR TITLE
Implement pot-specific growth rate multipliers in ProjectionEngine

### DIFF
--- a/src/utils/projectionEngine.ts
+++ b/src/utils/projectionEngine.ts
@@ -268,9 +268,17 @@ export function calculateLifetimeProjection(input: ProjectionEngineInput): Proje
       }
 
       // Apply Growth
-      trackingTaxable *= (1 + input.realGrowthRate / 100);
-      trackingTaxFree *= (1 + input.realGrowthRate / 100);
-      trackingPensions *= (1 + input.realGrowthRate / 100);
+      // Derive realistic net-of-inflation growth rates relative to the global macro base
+      // Taxable: Cash yields generally trail the macro rate + suffers minor unmodeled tax drag
+      const rateTaxable = (input.realGrowthRate * 0.4) / 100;
+      // Tax-Free: Cash ISA yields trail the macro rate but enjoy zero tax drag
+      const rateTaxFree = (input.realGrowthRate * 0.5) / 100;
+      // Pensions: Long-term equity/bond market returns outpace cash baseline compounding
+      const ratePensions = (input.realGrowthRate * 2.2) / 100;
+
+      trackingTaxable *= (1 + rateTaxable);
+      trackingTaxFree *= (1 + rateTaxFree);
+      trackingPensions *= (1 + ratePensions);
     } else {
       trackingTaxable = 0;
       trackingTaxFree = 0;

--- a/src/utils/projectionEngineGrowth.test.ts
+++ b/src/utils/projectionEngineGrowth.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import { calculateLifetimeProjection, type ProjectionEngineInput } from './projectionEngine';
+import { TAX_YEAR_CONSTANTS } from '../constants/taxConstants';
+
+describe('calculateLifetimeProjection Growth Rates', () => {
+  beforeAll(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-01-01T00:00:00.000Z'));
+  });
+
+  afterAll(() => {
+    vi.useRealTimers();
+  });
+
+  const dobP1 = new Date('1980-01-01T00:00:00.000Z').getTime();
+
+  const baseInput: ProjectionEngineInput = {
+    currentBalances: 0,
+    realGrowthRate: 10, // 10% for easy math
+    profile: {
+      partner1Dob: dobP1,
+    },
+    incomes: [],
+    budgets: [],
+    properties: [],
+    propertyOwnership: [],
+    taxRules: TAX_YEAR_CONSTANTS,
+  };
+
+  it('verifies pot-specific growth rates', () => {
+    const input: ProjectionEngineInput = {
+      ...baseInput,
+      assetPots: {
+        taxable: 1000,
+        taxFree: 1000,
+        pensions: 1000,
+      },
+    };
+
+    const results = calculateLifetimeProjection(input);
+
+    // After 1 year (2025)
+    // Expected with new logic:
+    // Taxable rate: 10 * 0.4 = 4% -> 1000 * 1.04 = 1040
+    // Tax-Free rate: 10 * 0.5 = 5% -> 1000 * 1.05 = 1050
+    // Pensions rate: 10 * 2.2 = 22% -> 1000 * 1.22 = 1220
+
+    // Note: If the code is NOT yet updated, they will all be 10% -> 1100
+
+    const year0 = results[0];
+
+    // We expect these to fail initially if we want to see them fail,
+    // but I'll write them as what we WANT.
+    expect(year0.potBalances.taxable).toBeCloseTo(1040, 2);
+    expect(year0.potBalances.taxFree).toBeCloseTo(1050, 2);
+    expect(year0.potBalances.pensions).toBeCloseTo(1220, 2);
+  });
+});


### PR DESCRIPTION
Modified the projection engine to apply realistic growth rate multipliers based on asset type: Taxable (0.4x), Tax-Free (0.5x), and Pensions (2.2x). Added a new test file to verify these specific growth rates.

Fixes #274

---
*PR created automatically by Jules for task [5491786811213318420](https://jules.google.com/task/5491786811213318420) started by @John-Bell*