### PR TITLE
Implement 15% effective tax rate on pension drawdowns

### DIFF
--- a/src/utils/pensionTaxDrag.test.ts
+++ b/src/utils/pensionTaxDrag.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeAll, afterAll } from 'vitest';
+import { calculateLifetimeProjection, type ProjectionEngineInput } from './projectionEngine';
+import { TAX_YEAR_CONSTANTS } from '../constants/taxConstants';
+
+describe('calculateLifetimeProjection Pension Tax Drag', () => {
+  beforeAll(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2025-01-01T00:00:00.000Z'));
+  });
+
+  afterAll(() => {
+    vi.useRealTimers();
+  });
+
+  const dobP1 = new Date('1980-01-01T00:00:00.000Z').getTime();
+
+  const baseInput: ProjectionEngineInput = {
+    currentBalances: 0,
+    realGrowthRate: 0, // Disable growth for simple verification
+    profile: {
+      partner1Dob: dobP1,
+    },
+    incomes: [],
+    budgets: [],
+    properties: [],
+    propertyOwnership: [],
+    taxRules: TAX_YEAR_CONSTANTS,
+  };
+
+  it('applies 15% tax drag on ordered pension drawdown', () => {
+    const input: ProjectionEngineInput = {
+      ...baseInput,
+      assetPots: {
+        taxable: 0,
+        taxFree: 0,
+        pensions: 100000,
+      },
+      drawdownStrategy: 'pensions_first',
+      budgets: [
+        {
+          id: 'budg-1',
+          accountId: 'acc-1',
+          name: 'Budget',
+          amount: 8500,
+          frequency: 'annually',
+          updatedAt: Date.now(),
+        },
+      ],
+    };
+
+    const results = calculateLifetimeProjection(input);
+
+    // Year 0 (2025):
+    // Deficit = 8500.
+    // effectiveTaxRate = 0.15.
+    // grossPensionWithdrawal = 8500 / (1 - 0.15) = 8500 / 0.85 = 10000.
+    // New pension balance should be 100000 - 10000 = 90000.
+
+    expect(results[0].potBalances.pensions).toBe(90000);
+    expect(results[0].liquidAssets).toBe(90000);
+  });
+
+  it('applies 15% tax drag on proportional pension drawdown', () => {
+    const input: ProjectionEngineInput = {
+      ...baseInput,
+      assetPots: {
+        taxable: 0,
+        taxFree: 0,
+        pensions: 100000,
+      },
+      drawdownStrategy: 'proportional',
+      budgets: [
+        {
+          id: 'budg-1',
+          accountId: 'acc-1',
+          name: 'Budget',
+          amount: 8500,
+          frequency: 'annually',
+          updatedAt: Date.now(),
+        },
+      ],
+    };
+
+    const results = calculateLifetimeProjection(input);
+
+    // Even with proportional, if ONLY pensions have balance, it should behave same as pensions_first.
+    // Deficit = 8500.
+    // Should draw 10000 gross to get 8500 net.
+    expect(results[0].potBalances.pensions).toBe(90000);
+  });
+});

--- a/src/utils/projectionEngine.test.ts
+++ b/src/utils/projectionEngine.test.ts
@@ -266,6 +266,16 @@ describe('calculateLifetimeProjection', () => {
     expect(results[2].potBalances.taxable).toBe(0);
     expect(results[2].potBalances.taxFree).toBe(50000);
     expect(results[2].potBalances.pensions).toBe(100000);
+
+    // Year 3 (2028): 150k - 50k = 100k total.
+    // taxFree was 50k. 50k - 50k = 0k. pensions: 100k.
+    expect(results[3].potBalances.taxFree).toBe(0);
+    expect(results[3].potBalances.pensions).toBe(100000);
+
+    // Year 4 (2029): 100k - 50k (net) = ?
+    // pensions: 100k - (50k / 0.85) = 100k - 58823.53 = 41176.47
+    expect(results[4].potBalances.pensions).toBeCloseTo(41176.47, 1);
+    expect(results[4].liquidAssets).toBeCloseTo(41176.47, 1);
   });
 
   it('TEST CASE 7: Proportional Drawdown Strategy', () => {
@@ -294,14 +304,16 @@ describe('calculateLifetimeProjection', () => {
     const results = calculateLifetimeProjection(input);
 
     // Total = 300k. Deficit = 30k (10%).
-    // Each pot should be reduced by 10%.
-    // taxable: 150k - 15k = 135k
-    // taxFree: 50k - 5k = 45k
-    // pensions: 100k - 10k = 90k
-    expect(results[0].liquidAssets).toBe(270000);
+    // Each pot should be reduced by its proportional share of the deficit.
+    // taxable share: 15k. New = 135k
+    // taxFree share: 5k. New = 45k
+    // pensions share: 10k net.
+    // To get 10k net from pensions, we need to draw 10k / 0.85 = 11,764.71 gross.
+    // pensions: 100k - 11764.71 = 88235.29
+    expect(results[0].liquidAssets).toBeCloseTo(268235.29, 1);
     expect(results[0].potBalances.taxable).toBe(135000);
     expect(results[0].potBalances.taxFree).toBe(45000);
-    expect(results[0].potBalances.pensions).toBe(90000);
+    expect(results[0].potBalances.pensions).toBeCloseTo(88235.29, 1);
   });
 
   it('TEST CASE 8: Bed & ISA Sweep - 2027 Start, No Emergency Floor, and Age-based Allowance', () => {

--- a/src/utils/projectionEngine.ts
+++ b/src/utils/projectionEngine.ts
@@ -4,6 +4,8 @@ import type { TaxRulesByYear } from '../constants/taxConstants';
 
 export type DrawdownStrategy = 'taxable_first' | 'tax_free_first' | 'pensions_first' | 'proportional';
 
+const PENSION_DRAWDOWN_TAX_RATE = 0.15;
+
 export interface ProjectionEngineInput {
   currentBalances: number; // Sum of active balances across liquid pots
   assetPots?: {
@@ -215,9 +217,13 @@ export function calculateLifetimeProjection(input: ProjectionEngineInput): Proje
             const ratioTaxFree = trackingTaxFree / totalAtStartOfDeficit;
             const ratioPensions = trackingPensions / totalAtStartOfDeficit;
 
-            trackingTaxable -= deficit * ratioTaxable;
-            trackingTaxFree -= deficit * ratioTaxFree;
-            trackingPensions -= deficit * ratioPensions;
+            // Apply realistic effective tax drag on the pension portion of the proportional drawdown
+            const pensionDrawNeeded = deficit * ratioPensions;
+            const grossPensionWithdrawal = pensionDrawNeeded / (1 - PENSION_DRAWDOWN_TAX_RATE);
+
+            trackingTaxable -= Math.min(trackingTaxable, deficit * ratioTaxable);
+            trackingTaxFree -= Math.min(trackingTaxFree, deficit * ratioTaxFree);
+            trackingPensions -= Math.min(trackingPensions, grossPensionWithdrawal);
           }
         } else {
           const order: ('taxable' | 'taxFree' | 'pensions')[] =
@@ -236,9 +242,17 @@ export function calculateLifetimeProjection(input: ProjectionEngineInput): Proje
               trackingTaxFree -= draw;
               deficit -= draw;
             } else if (pot === 'pensions') {
-              const draw = Math.min(trackingPensions, deficit);
-              trackingPensions -= draw;
-              deficit -= draw;
+              const drawNeeded = Math.min(trackingPensions, deficit);
+              // Define a realistic effective tax drag on DC pension withdrawals
+              // (Accounts for 75% taxable portion hitting basic/higher rate bands)
+              // Gross up the withdrawal: To get £85 net, you must pull £100 out of the pot
+              const grossPensionWithdrawal = drawNeeded / (1 - PENSION_DRAWDOWN_TAX_RATE);
+              // Ensure we don't draw more than the pot actually holds
+              const actualGrossDraw = Math.min(trackingPensions, grossPensionWithdrawal);
+              trackingPensions -= actualGrossDraw;
+              // The deficit is only reduced by the NET amount that lands in your bank account
+              const netDrawReceived = actualGrossDraw * (1 - PENSION_DRAWDOWN_TAX_RATE);
+              deficit -= netDrawReceived;
             }
           }
         }


### PR DESCRIPTION
This change implements a realistic 15% effective tax rate on funds withdrawn from the pension pot during the lifetime projection. It accounts for the tax drag by grossing up the withdrawal amount so that the net amount received covers the required deficit. The logic is applied consistently across both ordered and proportional drawdown strategies. Unit tests have been added and updated to verify the correct behavior.

Fixes #276

---
*PR created automatically by Jules for task [16090593154479293651](https://jules.google.com/task/16090593154479293651) started by @John-Bell*