### PR TITLE
Fix projection engine growth timing and rate

### DIFF
--- a/src/utils/projectionEngine.ts
+++ b/src/utils/projectionEngine.ts
@@ -281,18 +281,6 @@ export function calculateLifetimeProjection(input: ProjectionEngineInput): Proje
         }
       }
 
-      // Apply Growth
-      // Derive realistic net-of-inflation growth rates relative to the global macro base
-      // Taxable: Cash yields generally trail the macro rate + suffers minor unmodeled tax drag
-      const rateTaxable = (input.realGrowthRate * 0.4) / 100;
-      // Tax-Free: Cash ISA yields trail the macro rate but enjoy zero tax drag
-      const rateTaxFree = (input.realGrowthRate * 0.5) / 100;
-      // Pensions: Long-term equity/bond market returns outpace cash baseline compounding
-      const ratePensions = (input.realGrowthRate * 2.2) / 100;
-
-      trackingTaxable *= (1 + rateTaxable);
-      trackingTaxFree *= (1 + rateTaxFree);
-      trackingPensions *= (1 + ratePensions);
     } else {
       trackingTaxable = 0;
       trackingTaxFree = 0;
@@ -331,6 +319,21 @@ export function calculateLifetimeProjection(input: ProjectionEngineInput): Proje
 
     if (currentAgeP1 >= 100) {
       break;
+    }
+
+    // Apply Growth for the next year
+    if (trackingTotalLiquidAssets > 0) {
+      // Derive realistic net-of-inflation growth rates relative to the global macro base
+      // Taxable: Cash yields generally trail the macro rate + suffers minor unmodeled tax drag
+      const rateTaxable = (input.realGrowthRate * 0.4) / 100;
+      // Tax-Free: Cash ISA yields trail the macro rate but enjoy zero tax drag
+      const rateTaxFree = (input.realGrowthRate * 0.5) / 100;
+      // Pensions: Long-term equity/bond market returns outpace cash baseline compounding
+      const ratePensions = (input.realGrowthRate * 1.5) / 100;
+
+      trackingTaxable *= (1 + rateTaxable);
+      trackingTaxFree *= (1 + rateTaxFree);
+      trackingPensions *= (1 + ratePensions);
     }
 
     yearIndex++;

--- a/src/utils/projectionEngineGrowth.test.ts
+++ b/src/utils/projectionEngineGrowth.test.ts
@@ -27,7 +27,7 @@ describe('calculateLifetimeProjection Growth Rates', () => {
     taxRules: TAX_YEAR_CONSTANTS,
   };
 
-  it('verifies pot-specific growth rates', () => {
+  it('verifies pot-specific growth rates and timing', () => {
     const input: ProjectionEngineInput = {
       ...baseInput,
       assetPots: {
@@ -39,20 +39,20 @@ describe('calculateLifetimeProjection Growth Rates', () => {
 
     const results = calculateLifetimeProjection(input);
 
-    // After 1 year (2025)
+    // Year 0 (2025): Baseline, no growth applied yet
+    const year0 = results[0];
+    expect(year0.potBalances.taxable).toBe(1000);
+    expect(year0.potBalances.taxFree).toBe(1000);
+    expect(year0.potBalances.pensions).toBe(1000);
+
+    // Year 1 (2026): Growth from Year 0 applied at the end of Year 0 loop
     // Expected with new logic:
     // Taxable rate: 10 * 0.4 = 4% -> 1000 * 1.04 = 1040
     // Tax-Free rate: 10 * 0.5 = 5% -> 1000 * 1.05 = 1050
-    // Pensions rate: 10 * 2.2 = 22% -> 1000 * 1.22 = 1220
-
-    // Note: If the code is NOT yet updated, they will all be 10% -> 1100
-
-    const year0 = results[0];
-
-    // We expect these to fail initially if we want to see them fail,
-    // but I'll write them as what we WANT.
-    expect(year0.potBalances.taxable).toBeCloseTo(1040, 2);
-    expect(year0.potBalances.taxFree).toBeCloseTo(1050, 2);
-    expect(year0.potBalances.pensions).toBeCloseTo(1220, 2);
+    // Pensions rate: 10 * 1.5 = 15% -> 1000 * 1.15 = 1150
+    const year1 = results[1];
+    expect(year1.potBalances.taxable).toBeCloseTo(1040, 2);
+    expect(year1.potBalances.taxFree).toBeCloseTo(1050, 2);
+    expect(year1.potBalances.pensions).toBeCloseTo(1150, 2);
   });
 });


### PR DESCRIPTION
This PR fixes two issues in the lifetime projection engine:
1. **Growth Timing**: Previously, growth was applied before the year's results were pushed to the tracking array. This caused Year 0 (the current baseline) to have growth applied incorrectly. Growth is now applied at the end of the loop, so it affects the *next* year's starting point.
2. **Pension Growth Rate**: The multiplier for DC pension growth was overly optimistic at 2.2. It has been reduced to 1.5 per the user request.

Existing and updated unit tests verify these changes.

Fixes #278

---
*PR created automatically by Jules for task [2250771245399607173](https://jules.google.com/task/2250771245399607173) started by @John-Bell*