### PR TITLE
Add Protection Floor to Projection Engine and UI

### DIFF
--- a/src/hooks/useLifetimeProjection.ts
+++ b/src/hooks/useLifetimeProjection.ts
@@ -18,7 +18,15 @@ export function useLifetimeProjection(drawdownStrategy?: DrawdownStrategy) {
   return useMemo(() => {
     // Fallback Boundary
     if (!dbProfile || dbProfile.length === 0 || !dbProfile[0].partner1Dob) {
-      return { data: [] as ProjectionYearResult[], isReady: false, p1Name: 'Partner 1', p2Name: 'Partner 2', growthRate: 1.75 };
+      return {
+        data: [] as ProjectionYearResult[],
+        isReady: false,
+        p1Name: 'Partner 1',
+        p2Name: 'Partner 2',
+        growthRate: 1.75,
+        protectionFloor: 0,
+        settingsId: undefined as string | undefined
+      };
     }
 
     const activeProfile = dbProfile[0];
@@ -27,10 +35,19 @@ export function useLifetimeProjection(drawdownStrategy?: DrawdownStrategy) {
 
     // Ensure dependent data are loaded
     if (!dbAccounts || !dbIncomes || !dbBudgets || !dbProperties || !dbPropertyOwnership || !dbTaxRules || !dbSettings) {
-      return { data: [] as ProjectionYearResult[], isReady: false, p1Name, p2Name, growthRate: 1.75 };
+      return {
+        data: [] as ProjectionYearResult[],
+        isReady: false,
+        p1Name,
+        p2Name,
+        growthRate: 1.75,
+        protectionFloor: 0,
+        settingsId: undefined as string | undefined
+      };
     }
 
     const growthRate = dbSettings[0]?.defaultGrowthRate ?? 1.75;
+    const protectionFloor = dbSettings[0]?.protectionFloor ?? 0;
 
     // Calculate Initial Capital Pool
     const liquidCategories = [
@@ -108,6 +125,7 @@ export function useLifetimeProjection(drawdownStrategy?: DrawdownStrategy) {
       assetPots,
       drawdownStrategy,
       realGrowthRate: growthRate,
+      protectionFloor,
       profile: {
         partner1Dob: activeProfile.partner1Dob as number,
         partner2Dob: activeProfile.partner2Dob
@@ -124,7 +142,9 @@ export function useLifetimeProjection(drawdownStrategy?: DrawdownStrategy) {
       isReady: true,
       p1Name,
       p2Name,
-      growthRate
+      growthRate,
+      protectionFloor,
+      settingsId: dbSettings[0]?.id
     };
   }, [
     dbProfile,

--- a/src/lib/db.ts
+++ b/src/lib/db.ts
@@ -84,6 +84,7 @@ export interface Settings {
     syncPassphrase?: string;
     syncHeaderKey?: string;
     defaultGrowthRate?: number;
+    protectionFloor?: number;
 }
 
 export interface MonthlyArchive {
@@ -605,6 +606,14 @@ export const getSanitizedDbData = async (): Promise<Record<string, any[]>> => {
             annualGrowthRate: p.annualGrowthRate !== undefined ? Number(p.annualGrowthRate) : undefined,
             estimatedNetCashOnSale: p.estimatedNetCashOnSale !== undefined ? Number(p.estimatedNetCashOnSale) : undefined,
             estimatedSaleDate: p.estimatedSaleDate !== undefined ? Number(p.estimatedSaleDate) : undefined,
+        }));
+    }
+
+    if (rawData.settings) {
+        rawData.settings = rawData.settings.map(s => ({
+            ...s,
+            defaultGrowthRate: s.defaultGrowthRate !== undefined ? Number(s.defaultGrowthRate) : undefined,
+            protectionFloor: s.protectionFloor !== undefined ? Number(s.protectionFloor) : undefined,
         }));
     }
 

--- a/src/pages/AssetBurndownPage.tsx
+++ b/src/pages/AssetBurndownPage.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { db } from '@/lib/db';
 import { AppLayout } from '../components/layout/AppLayout';
 import { Header } from '../components/layout/Header';
 import { Icon } from '../components/ui/Icon';
@@ -10,7 +11,7 @@ import { cn } from '@/lib/utils';
 
 export function AssetBurndownPage() {
     const [strategy, setStrategy] = useState<DrawdownStrategy>('taxable_first');
-    const { data, isReady } = useLifetimeProjection(strategy);
+    const { data, isReady, protectionFloor, settingsId } = useLifetimeProjection(strategy);
 
     const firstPoint = isReady && data.length > 0 ? data[0] : null;
     const lastPoint = isReady && data.length > 0 ? data[data.length - 1] : null;
@@ -64,6 +65,42 @@ export function AssetBurndownPage() {
                                     <span className="sm:hidden">{s.label.split(' ')[0]}</span>
                                 </button>
                             ))}
+                        </div>
+
+                        {/* Simulation Configuration */}
+                        <div className="bg-white dark:bg-slate-900/50 p-4 rounded-xl border border-gray-100 dark:border-slate-800 space-y-3">
+                            <div className="flex items-center gap-2 mb-1">
+                                <Icon name="settings" className="text-primary text-lg" />
+                                <h3 className="text-sm font-bold text-slate-700 dark:text-slate-200 uppercase tracking-tight">Simulation Config</h3>
+                            </div>
+
+                            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                                <div className="space-y-1.5">
+                                    <label htmlFor="protectionFloor" className="text-[10px] font-bold text-slate-500 dark:text-primary/60 uppercase ml-1">
+                                        Taxable Protection Floor (£)
+                                    </label>
+                                    <div className="relative group">
+                                        <div className="absolute left-3 top-1/2 -translate-y-1/2 text-slate-400 group-focus-within:text-primary transition-colors">
+                                            <Icon name="account_balance_wallet" className="text-lg" />
+                                        </div>
+                                        <input
+                                            id="protectionFloor"
+                                            type="number"
+                                            value={protectionFloor ?? ''}
+                                            onChange={(e) => {
+                                                if (settingsId) {
+                                                    db.settings.update(settingsId, { protectionFloor: Number(e.target.value) || 0 });
+                                                }
+                                            }}
+                                            placeholder="e.g. 20000"
+                                            className="w-full bg-slate-50 dark:bg-primary/5 border border-slate-200 dark:border-primary/10 rounded-lg pl-10 pr-3 py-2.5 outline-none focus:ring-2 focus:ring-primary/20 transition-all font-medium"
+                                        />
+                                    </div>
+                                    <p className="text-[10px] text-slate-400 dark:text-slate-500 ml-1">
+                                        Minimum balance to keep in taxable accounts before drawing from SIPP/Pensions.
+                                    </p>
+                                </div>
+                            </div>
                         </div>
 
                         <div className="space-y-4">

--- a/src/utils/projectionEngine.test.ts
+++ b/src/utils/projectionEngine.test.ts
@@ -426,4 +426,97 @@ describe('calculateLifetimeProjection', () => {
     expect(r2031?.potBalances.taxable).toBe(132000);
     expect(r2031?.milestones[0]).toContain('£20,000 moved');
   });
+
+  it('TEST CASE 10: Taxable Protection Floor', () => {
+    const input: ProjectionEngineInput = {
+      ...baseInput,
+      currentBalances: 150000,
+      assetPots: {
+        taxable: 50000,
+        taxFree: 50000,
+        pensions: 50000,
+      },
+      protectionFloor: 20000,
+      drawdownStrategy: 'taxable_first',
+      realGrowthRate: 0,
+      budgets: [
+        {
+          id: 'budg-1',
+          accountId: 'acc-1',
+          name: 'Budget',
+          amount: 40000,
+          frequency: 'annually',
+          updatedAt: Date.now(),
+        },
+      ],
+    };
+
+    const results = calculateLifetimeProjection(input);
+
+    // Year 0 (2025): 150k - 40k = 110k total.
+    // strategy: taxable_first.
+    // Taxable available = 50k - 20k = 30k.
+    // Deficit = 40k.
+    // taxable draw = min(30k, 40k) = 30k.
+    // remaining deficit = 10k.
+    // taxFree draw = 10k.
+    // New Taxable = 50k - 30k = 20k.
+    // New taxFree = 50k - 10k = 40k.
+    // New pensions = 50k.
+    expect(results[0].potBalances.taxable).toBe(20000);
+    expect(results[0].potBalances.taxFree).toBe(40000);
+    expect(results[0].potBalances.pensions).toBe(50000);
+
+    // Year 1 (2026): 110k - 40k = 70k total.
+    // Taxable available = 20k - 20k = 0k.
+    // taxFree available = 40k.
+    // Deficit = 40k.
+    // taxFree draw = 40k.
+    // New Taxable = 20k.
+    // New taxFree = 0k.
+    // New pensions = 50k.
+    expect(results[1].potBalances.taxable).toBe(20000);
+    expect(results[1].potBalances.taxFree).toBe(0);
+    expect(results[1].potBalances.pensions).toBe(50000);
+  });
+
+  it('TEST CASE 11: Taxable Protection Floor (Proportional)', () => {
+    const input: ProjectionEngineInput = {
+      ...baseInput,
+      currentBalances: 120000,
+      assetPots: {
+        taxable: 40000,
+        taxFree: 40000,
+        pensions: 40000,
+      },
+      protectionFloor: 20000,
+      drawdownStrategy: 'proportional',
+      realGrowthRate: 0,
+      budgets: [
+        {
+          id: 'budg-1',
+          accountId: 'acc-1',
+          name: 'Budget',
+          amount: 20000,
+          frequency: 'annually',
+          updatedAt: Date.now(),
+        },
+      ],
+    };
+
+    const results = calculateLifetimeProjection(input);
+
+    // Initial: Taxable 40k, taxFree 40k, pensions 40k. Total = 120k.
+    // floor = 20k.
+    // availableTaxable = 40k - 20k = 20k.
+    // totalAvailable = 20k + 40k + 40k = 100k.
+    // Deficit = 20k.
+    // taxable share: 20k / 100k = 0.2. Draw = 20k * 0.2 = 4k. New Taxable = 40k - 4k = 36k.
+    // taxFree share: 40k / 100k = 0.4. Draw = 20k * 0.4 = 8k. New taxFree = 40k - 8k = 32k.
+    // pensions share: 40k / 100k = 0.4. Draw net = 20k * 0.4 = 8k.
+    // Gross draw = 8k / 0.85 = 9411.76. New pensions = 40k - 9411.76 = 30588.24.
+    expect(results[0].potBalances.taxable).toBe(36000);
+    expect(results[0].potBalances.taxFree).toBe(32000);
+    expect(results[0].potBalances.pensions).toBeCloseTo(30588.24, 1);
+  });
 });

--- a/src/utils/projectionEngine.ts
+++ b/src/utils/projectionEngine.ts
@@ -24,6 +24,7 @@ export interface ProjectionEngineInput {
   properties: Property[];
   propertyOwnership: PropertyOwnership[];
   taxRules: TaxRulesByYear;
+  protectionFloor?: number;
 }
 
 export interface ProjectionYearResult {
@@ -67,6 +68,8 @@ export function calculateLifetimeProjection(input: ProjectionEngineInput): Proje
   let trackingTaxable = input.assetPots?.taxable ?? input.currentBalances;
   let trackingTaxFree = input.assetPots?.taxFree ?? 0;
   let trackingPensions = input.assetPots?.pensions ?? 0;
+
+  const floor = input.protectionFloor ?? 0;
 
   const results: ProjectionYearResult[] = [];
 
@@ -211,9 +214,10 @@ export function calculateLifetimeProjection(input: ProjectionEngineInput): Proje
         const strategy = input.drawdownStrategy || 'proportional';
 
         if (strategy === 'proportional') {
-          const totalAtStartOfDeficit = trackingTaxable + trackingTaxFree + trackingPensions;
+          const availableTaxable = Math.max(0, trackingTaxable - floor);
+          const totalAtStartOfDeficit = availableTaxable + trackingTaxFree + trackingPensions;
           if (totalAtStartOfDeficit > 0) {
-            const ratioTaxable = trackingTaxable / totalAtStartOfDeficit;
+            const ratioTaxable = availableTaxable / totalAtStartOfDeficit;
             const ratioTaxFree = trackingTaxFree / totalAtStartOfDeficit;
             const ratioPensions = trackingPensions / totalAtStartOfDeficit;
 
@@ -221,7 +225,7 @@ export function calculateLifetimeProjection(input: ProjectionEngineInput): Proje
             const pensionDrawNeeded = deficit * ratioPensions;
             const grossPensionWithdrawal = pensionDrawNeeded / (1 - PENSION_DRAWDOWN_TAX_RATE);
 
-            trackingTaxable -= Math.min(trackingTaxable, deficit * ratioTaxable);
+            trackingTaxable -= Math.min(availableTaxable, deficit * ratioTaxable);
             trackingTaxFree -= Math.min(trackingTaxFree, deficit * ratioTaxFree);
             trackingPensions -= Math.min(trackingPensions, grossPensionWithdrawal);
           }
@@ -234,7 +238,8 @@ export function calculateLifetimeProjection(input: ProjectionEngineInput): Proje
           for (const pot of order) {
             if (deficit <= 0) break;
             if (pot === 'taxable') {
-              const draw = Math.min(trackingTaxable, deficit);
+              const available = Math.max(0, trackingTaxable - floor);
+              const draw = Math.min(available, deficit);
               trackingTaxable -= draw;
               deficit -= draw;
             } else if (pot === 'taxFree') {


### PR DESCRIPTION
This change implements a "Taxable Protection Floor" feature in the lifetime financial projection engine.

1. **Database**: Added `protectionFloor` to the `Settings` interface in `src/lib/db.ts` and ensured it is sanitized to a number during data export.
2. **Projection Engine**: Modified `src/utils/projectionEngine.ts` to treat the taxable pot as "empty" for deficit coverage purposes once it hits the user-defined floor. This applies to both the ordered and proportional drawdown strategies.
3. **Hook Integration**: Updated `src/hooks/useLifetimeProjection.ts` to retrieve this value from settings and pass it to the engine, enabling real-time chart updates when the floor changes.
4. **UI**: Added a new "Simulation Config" section to `AssetBurndownPage.tsx` with a numeric input for the floor.
5. **Testing**: Added `TEST CASE 10` and `11` to `src/utils/projectionEngine.test.ts` to verify the floor behavior across different drawdown strategies. Verified UI functionality with Playwright.

Fixes #280

---
*PR created automatically by Jules for task [3523236580787380908](https://jules.google.com/task/3523236580787380908) started by @John-Bell*