### PR TITLE
Remove redundant property links from side menu

### DIFF
--- a/src/components/layout/SideMenu.tsx
+++ b/src/components/layout/SideMenu.tsx
@@ -157,30 +157,6 @@ export function SideMenu({ isOpen, onClose }: SideMenuProps) {
                             Properties
                         </span>
                     </button>
-                    <button
-                        type="button"
-                        onClick={() => handleNavigate('/property-ownerships')}
-                        className="flex items-center gap-4 w-full p-3 rounded-xl hover:bg-slate-100 dark:hover:bg-surface-dark transition-colors text-left cursor-pointer group"
-                    >
-                        <div className="w-10 h-10 rounded-full bg-slate-200 dark:bg-black/30 flex items-center justify-center text-slate-700 dark:text-slate-300 group-hover:text-primary transition-colors">
-                            <Icon name="handshake" className="text-xl" />
-                        </div>
-                        <span className="font-semibold text-slate-700 dark:text-slate-200 group-hover:text-slate-900 dark:group-hover:text-white transition-colors">
-                            Property Ownerships
-                        </span>
-                    </button>
-                    <button
-                        type="button"
-                        onClick={() => handleNavigate('/property-expenses')}
-                        className="flex items-center gap-4 w-full p-3 rounded-xl hover:bg-slate-100 dark:hover:bg-surface-dark transition-colors text-left cursor-pointer group"
-                    >
-                        <div className="w-10 h-10 rounded-full bg-slate-200 dark:bg-black/30 flex items-center justify-center text-slate-700 dark:text-slate-300 group-hover:text-primary transition-colors">
-                            <Icon name="receipt_long" className="text-xl" />
-                        </div>
-                        <span className="font-semibold text-slate-700 dark:text-slate-200 group-hover:text-slate-900 dark:group-hover:text-white transition-colors">
-                            Property Expenses
-                        </span>
-                    </button>
                     {/* Add more menu items here in the future */}
                 </nav>
 


### PR DESCRIPTION
I have removed the 'Property Ownerships' and 'Property Expenses' navigation items from the side menu in `src/components/layout/SideMenu.tsx`. These pages are intended to be accessed through the 'Properties' page, making their inclusion in the side menu redundant.

Key changes:
- Deleted the navigation buttons for `/property-ownerships` and `/property-expenses` from the `SideMenu` component.
- Verified that 'Properties' remains accessible and that the other two items are gone.
- Ran unit tests and existing Playwright tests to ensure no regressions.
- Performed a custom Playwright verification to confirm the visual change.

Fixes #284

---
*PR created automatically by Jules for task [12046032354374395737](https://jules.google.com/task/12046032354374395737) started by @John-Bell*