### PR TITLE
Add annual outgoings and net cashflow to asset burndown chart

### DIFF
--- a/src/components/scenarios/AssetBurndownChart.tsx
+++ b/src/components/scenarios/AssetBurndownChart.tsx
@@ -125,6 +125,22 @@ const AssetBurndownChart: React.FC<AssetBurndownChartProps> = ({ drawdownStrateg
           </div>
         </div>
 
+        {/* Secondary Financial Metrics Sub-Grid */}
+        <div className="grid grid-cols-2 gap-3 mt-3 pt-3 border-t border-dashed border-gray-100 dark:border-slate-800">
+          <div>
+            <span className="block text-[10px] uppercase font-bold text-slate-400 tracking-wider">Annual Outgoings</span>
+            <span className="text-sm font-semibold text-slate-700 dark:text-slate-200">
+              {formatCurrency(displayPoint.annualBudget || 0)}
+            </span>
+          </div>
+          <div>
+            <span className="block text-[10px] uppercase font-bold text-slate-400 tracking-wider">Net Cashflow</span>
+            <span className={`text-sm font-bold ${(displayPoint.netCashFlow || 0) >= 0 ? 'text-emerald-600' : 'text-rose-600'}`}>
+              {(displayPoint.netCashFlow || 0) >= 0 ? '+' : ''}{formatCurrency(displayPoint.netCashFlow || 0)}
+            </span>
+          </div>
+        </div>
+
         {/* Milestones Row */}
         {displayPoint.milestones && displayPoint.milestones.length > 0 && (
           <div className="mt-3 pt-3 border-t border-dashed border-gray-100 dark:border-slate-800">


### PR DESCRIPTION
This change adds two new financial metrics, "Annual Outgoings" and "Net Cashflow", to the header readout of the `AssetBurndownChart` component. 

Key changes:
- Inserted a 2-column grid in the chart header to display `annualBudget` and `netCashFlow` from the active projection year.
- Applied consistent styling with `LifetimeProjectionChart`, including color-coding for positive (emerald-600) and negative (rose-600) cashflow.
- Verified the layout and data display using a Playwright integration test.
- Ensured all existing unit tests for the projection engine and UI components continue to pass.

Fixes #288

---
*PR created automatically by Jules for task [1269061042512033135](https://jules.google.com/task/1269061042512033135) started by @John-Bell*