### PR TITLE
Add 'DC Pension (Post-Drawdown)' account category

### DIFF
--- a/src/constants/taxConstants.ts
+++ b/src/constants/taxConstants.ts
@@ -55,7 +55,8 @@ export type AccountCategory =
   | 'Cash ISA'
   | 'Shares ISA'
   | 'Premium Bonds'
-  | 'DC Pension';
+  | 'DC Pension'
+  | 'DC Pension (Post-Drawdown)';
 
 export const ACCOUNT_CATEGORIES: AccountCategory[] = [
   'Current Account',
@@ -66,14 +67,16 @@ export const ACCOUNT_CATEGORIES: AccountCategory[] = [
   'Cash ISA',
   'Shares ISA',
   'Premium Bonds',
-  'DC Pension'
+  'DC Pension',
+  'DC Pension (Post-Drawdown)'
 ];
 
 export const TAX_FREE_CATEGORIES: AccountCategory[] = [
   'Cash ISA',
   'Shares ISA',
   'Premium Bonds',
-  'DC Pension'
+  'DC Pension',
+  'DC Pension (Post-Drawdown)'
 ];
 
 const DEFAULT_TAX_YEAR = '2025-2026';

--- a/src/hooks/useLifetimeProjection.ts
+++ b/src/hooks/useLifetimeProjection.ts
@@ -59,6 +59,7 @@ export function useLifetimeProjection(drawdownStrategy?: DrawdownStrategy) {
       'Cash ISA',
       'Shares ISA',
       'DC Pension',
+      'DC Pension (Post-Drawdown)',
       'Stocks & Shares',
       'Premium Bonds'
     ];
@@ -69,13 +70,13 @@ export function useLifetimeProjection(drawdownStrategy?: DrawdownStrategy) {
 
     const assetPots = {
       taxable: dbAccounts
-        .filter(a => liquidCategories.includes(a.category) && !['Cash ISA', 'Shares ISA', 'Premium Bonds', 'DC Pension'].includes(a.category))
+        .filter(a => liquidCategories.includes(a.category) && !['Cash ISA', 'Shares ISA', 'Premium Bonds', 'DC Pension', 'DC Pension (Post-Drawdown)'].includes(a.category))
         .reduce((sum, a) => sum + a.balance, 0),
       taxFree: dbAccounts
         .filter(a => ['Cash ISA', 'Shares ISA', 'Premium Bonds'].includes(a.category))
         .reduce((sum, a) => sum + a.balance, 0),
       pensions: dbAccounts
-        .filter(a => a.category === 'DC Pension')
+        .filter(a => a.category === 'DC Pension' || a.category === 'DC Pension (Post-Drawdown)')
         .reduce((sum, a) => sum + a.balance, 0)
     };
 

--- a/src/services/accountCalculations.test.ts
+++ b/src/services/accountCalculations.test.ts
@@ -134,6 +134,14 @@ describe('calculateTaxableSavings', () => {
         expect(calculateTaxableSavings(accounts)).toBe(100);
     });
 
+    it('excludes DC Pension (Post-Drawdown) accounts', () => {
+        const accounts: Account[] = [
+            { id: '1', name: 'Acc 1', balance: 100, ownerId: 'p1', updatedAt: 0, category: 'Current Account', interestRate: 0 },
+            { id: '2', name: 'Acc 2', balance: 500, ownerId: 'p2', updatedAt: 0, category: 'DC Pension (Post-Drawdown)', interestRate: 0 },
+        ];
+        expect(calculateTaxableSavings(accounts)).toBe(100);
+    });
+
     it('excludes Premium Bonds accounts', () => {
         const accounts: Account[] = [
             { id: '1', name: 'Acc 1', balance: 100, ownerId: 'p1', updatedAt: 0, category: 'Current Account', interestRate: 0 },
@@ -194,6 +202,14 @@ describe('calculateProjectedTaxableInterest', () => {
         const accounts: Account[] = [
             { id: '1', name: 'Acc 1', balance: 1000, ownerId: 'p1', updatedAt: 0, category: 'Current Account', interestRate: 5 },
             { id: '2', name: 'Acc 2', balance: 5000, ownerId: 'p2', updatedAt: 0, category: 'DC Pension', interestRate: 10 },
+        ];
+        expect(calculateProjectedTaxableInterest(accounts, [], startTs, endTs)).toBeCloseTo(50, 4);
+    });
+
+    it('excludes DC Pension (Post-Drawdown) accounts from interest calculation', () => {
+        const accounts: Account[] = [
+            { id: '1', name: 'Acc 1', balance: 1000, ownerId: 'p1', updatedAt: 0, category: 'Current Account', interestRate: 5 },
+            { id: '2', name: 'Acc 2', balance: 5000, ownerId: 'p2', updatedAt: 0, category: 'DC Pension (Post-Drawdown)', interestRate: 10 },
         ];
         expect(calculateProjectedTaxableInterest(accounts, [], startTs, endTs)).toBeCloseTo(50, 4);
     });

--- a/src/services/accountCalculations.ts
+++ b/src/services/accountCalculations.ts
@@ -7,7 +7,7 @@ export function calculateTotalSavings(accounts: Account[]): number {
 }
 
 export function calculateNonPensionSavings(accounts: Account[]): number {
-    return accounts.reduce((sum, acc) => acc.category !== 'DC Pension' ? sum + (acc.balance || 0) : sum, 0);
+    return accounts.reduce((sum, acc) => (acc.category !== 'DC Pension' && acc.category !== 'DC Pension (Post-Drawdown)') ? sum + (acc.balance || 0) : sum, 0);
 }
 
 export function calculateTaxableSavings(accounts: Account[]): number {

--- a/src/utils/accountRules.ts
+++ b/src/utils/accountRules.ts
@@ -1,7 +1,7 @@
 import { type AccountCategory } from '@/constants/taxConstants';
 
 export const canShowAER = (category: string | AccountCategory): boolean => {
-    return category === '' || !['Stocks & Shares', 'Shares ISA', 'DC Pension', 'Premium Bonds'].includes(category as string);
+    return category === '' || !['Stocks & Shares', 'Shares ISA', 'DC Pension', 'DC Pension (Post-Drawdown)', 'Premium Bonds'].includes(category as string);
 };
 
 export const canShowBonus = (category: string | AccountCategory): boolean => {


### PR DESCRIPTION
This PR introduces a new account category: 'DC Pension (Post-Drawdown)'. 

Key changes:
1. **Category Definition**: Added to `src/constants/taxConstants.ts`. It is also marked as a tax-free category for internal interest/growth purposes.
2. **Projection Engine Integration**: Updated `src/hooks/useLifetimeProjection.ts` to ensure accounts in this category are correctly aggregated into the 'pensions' pot rather than the 'taxable' pot.
3. **Calculation Consistency**: Updated `src/services/accountCalculations.ts` to treat it as a pension asset in `calculateNonPensionSavings`.
4. **UI Rules**: Updated `src/utils/accountRules.ts` so that the AER input is hidden when this category is selected, matching the behavior of existing pension categories.
5. **Testing**: Added unit tests to `src/services/accountCalculations.test.ts` to verify correct handling of the new category in taxable savings and interest projections.

This lays the groundwork for future projection engine updates that will handle the specific tax treatment of post-drawdown pension withdrawals.

Fixes #290

---
*PR created automatically by Jules for task [4556920838264179447](https://jules.google.com/task/4556920838264179447) started by @John-Bell*