### PR TITLE
Derive AccountCategory type from array constant

### DIFF
--- a/src/constants/taxConstants.ts
+++ b/src/constants/taxConstants.ts
@@ -46,19 +46,7 @@ export type TaxYearConstants = {
   StartingBand: string;
 };
 
-export type AccountCategory =
-  | 'Current Account'
-  | 'Easy Access Savings'
-  | 'Fixed Term Savings'
-  | 'Notice Savings'
-  | 'Stocks & Shares'
-  | 'Cash ISA'
-  | 'Shares ISA'
-  | 'Premium Bonds'
-  | 'DC Pension'
-  | 'DC Pension (Post-Drawdown)';
-
-export const ACCOUNT_CATEGORIES: AccountCategory[] = [
+export const ACCOUNT_CATEGORIES = [
   'Current Account',
   'Easy Access Savings',
   'Fixed Term Savings',
@@ -68,8 +56,10 @@ export const ACCOUNT_CATEGORIES: AccountCategory[] = [
   'Shares ISA',
   'Premium Bonds',
   'DC Pension',
-  'DC Pension (Post-Drawdown)'
-];
+  'DC Pension (Post-Drawdown)',
+] as const;
+
+export type AccountCategory = (typeof ACCOUNT_CATEGORIES)[number];
 
 export const TAX_FREE_CATEGORIES: AccountCategory[] = [
   'Cash ISA',


### PR DESCRIPTION
Refactored `src/constants/taxConstants.ts` to derive the `AccountCategory` type from the `ACCOUNT_CATEGORIES` array. This ensures that the type and the array are always in sync and follows TypeScript best practices for string literal unions.

Changes:
- Defined `ACCOUNT_CATEGORIES` as a const array using `as const`.
- Derived `AccountCategory` type using `typeof ACCOUNT_CATEGORIES[number]`.
- Verified with `npm run build` and `npx vitest run`.
- Visually verified via Playwright screenshot.

Fixes #292

---
*PR created automatically by Jules for task [7383640699371004628](https://jules.google.com/task/7383640699371004628) started by @John-Bell*