### PR TITLE
Refactor Pension Drawdown to Support Strict Partial Crystallisation

### DIFF
--- a/src/hooks/useLifetimeProjection.ts
+++ b/src/hooks/useLifetimeProjection.ts
@@ -80,6 +80,15 @@ export function useLifetimeProjection(drawdownStrategy?: DrawdownStrategy) {
         .reduce((sum, a) => sum + a.balance, 0)
     };
 
+    const pensionPots = dbAccounts
+      .filter(a => a.category === 'DC Pension' || a.category === 'DC Pension (Post-Drawdown)')
+      .map(a => ({
+        id: a.id,
+        ownerId: a.ownerId as 'person1' | 'person2',
+        balance: a.balance,
+        category: a.category
+      }));
+
     // Reduce tax rules into a keyed map dictionary
     const reducedTaxRulesMap: TaxRulesByYear = dbTaxRules.reduce((acc, rule) => {
       acc[rule.id] = {
@@ -125,6 +134,7 @@ export function useLifetimeProjection(drawdownStrategy?: DrawdownStrategy) {
     const projectionData = calculateLifetimeProjection({
       currentBalances: totalLiquidBalances,
       assetPots,
+      pensionPots,
       drawdownStrategy,
       realGrowthRate: growthRate,
       protectionFloor,

--- a/src/utils/projectionEngine.ts
+++ b/src/utils/projectionEngine.ts
@@ -13,6 +13,12 @@ export interface ProjectionEngineInput {
     taxFree: number;
     pensions: number;
   };
+  pensionPots?: {
+    id: string;
+    ownerId: 'person1' | 'person2';
+    balance: number;
+    category: string;
+  }[];
   drawdownStrategy?: DrawdownStrategy;
   realGrowthRate: number;  // App global growth asset rate (e.g., 2.38)
   profile: {
@@ -68,7 +74,16 @@ export function calculateLifetimeProjection(input: ProjectionEngineInput): Proje
 
   let trackingTaxable = input.assetPots?.taxable ?? input.currentBalances;
   let trackingTaxFree = input.assetPots?.taxFree ?? 0;
-  let trackingPensions = input.assetPots?.pensions ?? 0;
+
+  let trackingPensions = input.pensionPots ? JSON.parse(JSON.stringify(input.pensionPots)) : [];
+  if (!input.pensionPots && input.assetPots?.pensions) {
+    trackingPensions.push({
+      id: 'dummy-pension',
+      ownerId: 'person1',
+      balance: input.assetPots.pensions,
+      category: 'DC Pension (Post-Drawdown)' // Crystallised for backwards-compatibility of flat tax tests
+    });
+  }
 
   const floor = input.protectionFloor ?? 0;
 
@@ -212,7 +227,8 @@ export function calculateLifetimeProjection(input: ProjectionEngineInput): Proje
     const totalInflows = (p1Salary + p1Pension + p1Dividends + p2Salary + p2Pension + p2Dividends) + p1RentalGrossForYear + p2RentalGrossForYear;
     const netCashFlow = totalInflows - totalBudgetsForYear - totalTaxForYear;
 
-    const totalBefore = trackingTaxable + trackingTaxFree + trackingPensions;
+    const totalPensions = trackingPensions.reduce((sum: number, p: any) => sum + p.balance, 0);
+    const totalBefore = trackingTaxable + trackingTaxFree + totalPensions;
 
     if (totalBefore > 0 || totalCashInjectionsForYear > 0) {
       let annualSurplus = netCashFlow + totalCashInjectionsForYear;
@@ -225,14 +241,14 @@ export function calculateLifetimeProjection(input: ProjectionEngineInput): Proje
 
         if (strategy === 'proportional') {
           const availableCash = Math.max(0, (trackingTaxable + trackingTaxFree) - floor);
-          const totalAtStartOfDeficit = availableCash + trackingPensions;
+          const currentTotalPensions = trackingPensions.reduce((sum: number, p: any) => sum + p.balance, 0);
+          const totalAtStartOfDeficit = availableCash + currentTotalPensions;
           if (totalAtStartOfDeficit > 0) {
             const ratioCash = availableCash / totalAtStartOfDeficit;
-            const ratioPensions = trackingPensions / totalAtStartOfDeficit;
+            const ratioPensions = currentTotalPensions / totalAtStartOfDeficit;
 
             const cashDrawNeeded = deficit * ratioCash;
-            const pensionDrawNeeded = deficit * ratioPensions;
-            const grossPensionWithdrawal = pensionDrawNeeded / (1 - PENSION_DRAWDOWN_TAX_RATE);
+            let pensionDrawNeeded = deficit * ratioPensions;
 
             // Split cashDrawNeeded between taxable and taxFree proportionally to their current relative balances
             const totalCash = trackingTaxable + trackingTaxFree;
@@ -243,7 +259,44 @@ export function calculateLifetimeProjection(input: ProjectionEngineInput): Proje
               trackingTaxFree -= Math.min(trackingTaxFree, cashDrawNeeded * ratioTaxFree);
             }
 
-            trackingPensions -= Math.min(trackingPensions, grossPensionWithdrawal);
+            // Iterate over pension pots to fulfill pensionDrawNeeded
+            for (const pot of trackingPensions) {
+              if (pensionDrawNeeded <= 0) break;
+              if (pot.balance <= 0) continue;
+
+              if (pot.category === 'DC Pension') {
+                const requiredCrystallisation = pensionDrawNeeded * 4;
+                if (pot.balance >= requiredCrystallisation) {
+                  pot.balance -= requiredCrystallisation;
+                  pensionDrawNeeded -= pensionDrawNeeded;
+                  let postPot = trackingPensions.find((p: any) => p.category === 'DC Pension (Post-Drawdown)' && p.ownerId === pot.ownerId);
+                  if (!postPot) {
+                    postPot = { id: `post-${pot.id}-${yearIndex}`, ownerId: pot.ownerId, balance: 0, category: 'DC Pension (Post-Drawdown)' };
+                    trackingPensions.push(postPot);
+                  }
+                  postPot.balance += requiredCrystallisation * 0.75;
+                } else {
+                  const availableTaxFree = pot.balance * 0.25;
+                  pensionDrawNeeded -= availableTaxFree;
+                  let postPot = trackingPensions.find((p: any) => p.category === 'DC Pension (Post-Drawdown)' && p.ownerId === pot.ownerId);
+                  if (!postPot) {
+                    postPot = { id: `post-${pot.id}-${yearIndex}`, ownerId: pot.ownerId, balance: 0, category: 'DC Pension (Post-Drawdown)' };
+                    trackingPensions.push(postPot);
+                  }
+                  postPot.balance += pot.balance * 0.75;
+                  pot.balance = 0;
+                }
+              } else if (pot.category === 'DC Pension (Post-Drawdown)') {
+                const grossWithdrawal = pensionDrawNeeded / (1 - PENSION_DRAWDOWN_TAX_RATE);
+                if (pot.balance >= grossWithdrawal) {
+                  pot.balance -= grossWithdrawal;
+                  pensionDrawNeeded = 0;
+                } else {
+                  pensionDrawNeeded -= pot.balance * (1 - PENSION_DRAWDOWN_TAX_RATE);
+                  pot.balance = 0;
+                }
+              }
+            }
           }
         } else {
           const order: ('taxable' | 'taxFree' | 'pensions')[] =
@@ -266,17 +319,43 @@ export function calculateLifetimeProjection(input: ProjectionEngineInput): Proje
               deficit -= draw;
               availableCash -= draw;
             } else if (pot === 'pensions') {
-              const drawNeeded = Math.min(trackingPensions, deficit);
-              // Define a realistic effective tax drag on DC pension withdrawals
-              // (Accounts for 75% taxable portion hitting basic/higher rate bands)
-              // Gross up the withdrawal: To get £85 net, you must pull £100 out of the pot
-              const grossPensionWithdrawal = drawNeeded / (1 - PENSION_DRAWDOWN_TAX_RATE);
-              // Ensure we don't draw more than the pot actually holds
-              const actualGrossDraw = Math.min(trackingPensions, grossPensionWithdrawal);
-              trackingPensions -= actualGrossDraw;
-              // The deficit is only reduced by the NET amount that lands in your bank account
-              const netDrawReceived = actualGrossDraw * (1 - PENSION_DRAWDOWN_TAX_RATE);
-              deficit -= netDrawReceived;
+              for (const pPot of trackingPensions) {
+                if (deficit <= 0) break;
+                if (pPot.balance <= 0) continue;
+
+                if (pPot.category === 'DC Pension') {
+                  const requiredCrystallisation = deficit * 4;
+                  if (pPot.balance >= requiredCrystallisation) {
+                    pPot.balance -= requiredCrystallisation;
+                    deficit -= deficit;
+                    let postPot = trackingPensions.find((p: any) => p.category === 'DC Pension (Post-Drawdown)' && p.ownerId === pPot.ownerId);
+                    if (!postPot) {
+                      postPot = { id: `post-${pPot.id}-${yearIndex}`, ownerId: pPot.ownerId, balance: 0, category: 'DC Pension (Post-Drawdown)' };
+                      trackingPensions.push(postPot);
+                    }
+                    postPot.balance += requiredCrystallisation * 0.75;
+                  } else {
+                    const availableTaxFree = pPot.balance * 0.25;
+                    deficit -= availableTaxFree;
+                    let postPot = trackingPensions.find((p: any) => p.category === 'DC Pension (Post-Drawdown)' && p.ownerId === pPot.ownerId);
+                    if (!postPot) {
+                      postPot = { id: `post-${pPot.id}-${yearIndex}`, ownerId: pPot.ownerId, balance: 0, category: 'DC Pension (Post-Drawdown)' };
+                      trackingPensions.push(postPot);
+                    }
+                    postPot.balance += pPot.balance * 0.75;
+                    pPot.balance = 0;
+                  }
+                } else if (pPot.category === 'DC Pension (Post-Drawdown)') {
+                  const grossWithdrawal = deficit / (1 - PENSION_DRAWDOWN_TAX_RATE);
+                  if (pPot.balance >= grossWithdrawal) {
+                    pPot.balance -= grossWithdrawal;
+                    deficit = 0;
+                  } else {
+                    deficit -= pPot.balance * (1 - PENSION_DRAWDOWN_TAX_RATE);
+                    pPot.balance = 0;
+                  }
+                }
+              }
             }
           }
         }
@@ -308,15 +387,18 @@ export function calculateLifetimeProjection(input: ProjectionEngineInput): Proje
     } else {
       trackingTaxable = 0;
       trackingTaxFree = 0;
-      trackingPensions = 0;
+      for (const pot of trackingPensions) pot.balance = 0;
     }
 
     // Floor and handle runway
     if (trackingTaxable < 0) trackingTaxable = 0;
     if (trackingTaxFree < 0) trackingTaxFree = 0;
-    if (trackingPensions < 0) trackingPensions = 0;
+    for (const pot of trackingPensions) {
+      if (pot.balance < 0) pot.balance = 0;
+    }
 
-    const trackingTotalLiquidAssets = trackingTaxable + trackingTaxFree + trackingPensions;
+    const currentTotalPensionsAfterDrawdown = trackingPensions.reduce((sum: number, p: any) => sum + p.balance, 0);
+    const trackingTotalLiquidAssets = trackingTaxable + trackingTaxFree + currentTotalPensionsAfterDrawdown;
 
     let isRunwayBroken = false;
     if (trackingTotalLiquidAssets <= 0) {
@@ -332,7 +414,7 @@ export function calculateLifetimeProjection(input: ProjectionEngineInput): Proje
       potBalances: {
         taxable: trackingTaxable,
         taxFree: trackingTaxFree,
-        pensions: trackingPensions,
+        pensions: currentTotalPensionsAfterDrawdown,
         total: trackingTotalLiquidAssets
       },
       isRunwayBroken: isRunwayBroken,
@@ -357,7 +439,9 @@ export function calculateLifetimeProjection(input: ProjectionEngineInput): Proje
 
       trackingTaxable *= (1 + rateTaxable);
       trackingTaxFree *= (1 + rateTaxFree);
-      trackingPensions *= (1 + ratePensions);
+      for (const pot of trackingPensions) {
+        pot.balance *= (1 + ratePensions);
+      }
     }
 
     yearIndex++;


### PR DESCRIPTION
This branch refactors the `calculateLifetimeProjection` engine inside `projectionEngine.ts` to implement strict partial crystallisation mechanics for distinct pension pots, completely addressing the user's architectural and functional requirements.

**Key Changes:**
- **`ProjectionEngineInput`:** Added an optional `pensionPots` array of objects (containing `id`, `ownerId`, `balance`, and `category`) to replace the monolithic `assetPots.pensions` number.
- **`calculateLifetimeProjection`:**
  - Removed the single `trackingPensions` integer, replacing it with an array cloned from `pensionPots`. 
  - Included fallback logic for existing tests: if `pensionPots` is absent but `assetPots.pensions` exists, it instantiates a dummy 'DC Pension (Post-Drawdown)' pot to ensure flat-tax test suites pass.
  - Re-engineered the inner drawdown loop for `pensions` to iterate over all tracking pots.
  - Implemented the requested partial crystallisation logic for Uncrystallised pots (`DC Pension`): Covering `amountNeeded` requires reducing the pot by `amountNeeded * 4`, with the remaining 75% being moved to a dynamically identified or constructed 'DC Pension (Post-Drawdown)' pot for the same `ownerId`. 
  - Retained the 15% tax drag logic on Crystallised pots (`DC Pension (Post-Drawdown)`).
  - Modified the compound growth logic at the end of each simulated year to apply the 1.5x pension multiplier across every internal pot object.
  - Aggregated final tracking amounts dynamically from the mutated array.
- **`useLifetimeProjection`:** 
  - Updated the hook to filter `dbAccounts` and pass down a properly typed `pensionPots` array into the engine.
- **Testing:** Confirmed pure TypeScript constraints and ensured the `124` tests inside Vitest execute successfully without modifying database models.

---
*PR created automatically by Jules for task [5637130936886037196](https://jules.google.com/task/5637130936886037196) started by @John-Bell*