### PR TITLE
Fix pension pot sorting in drawdown logic

### DIFF
--- a/src/utils/projectionEngine.ts
+++ b/src/utils/projectionEngine.ts
@@ -259,6 +259,13 @@ export function calculateLifetimeProjection(input: ProjectionEngineInput): Proje
               trackingTaxFree -= Math.min(trackingTaxFree, cashDrawNeeded * ratioTaxFree);
             }
 
+            // Sort pension pots: Uncrystallised ('DC Pension') first, then Crystallised
+            trackingPensions.sort((a: any, b: any) => {
+              if (a.category === 'DC Pension' && b.category !== 'DC Pension') return -1;
+              if (a.category !== 'DC Pension' && b.category === 'DC Pension') return 1;
+              return 0;
+            });
+
             // Iterate over pension pots to fulfill pensionDrawNeeded
             for (const pot of trackingPensions) {
               if (pensionDrawNeeded <= 0) break;
@@ -319,6 +326,13 @@ export function calculateLifetimeProjection(input: ProjectionEngineInput): Proje
               deficit -= draw;
               availableCash -= draw;
             } else if (pot === 'pensions') {
+              // Sort pension pots: Uncrystallised ('DC Pension') first, then Crystallised
+              trackingPensions.sort((a: any, b: any) => {
+                if (a.category === 'DC Pension' && b.category !== 'DC Pension') return -1;
+                if (a.category !== 'DC Pension' && b.category === 'DC Pension') return 1;
+                return 0;
+              });
+
               for (const pPot of trackingPensions) {
                 if (deficit <= 0) break;
                 if (pPot.balance <= 0) continue;


### PR DESCRIPTION
This commit adds the missing sorting logic for the `trackingPensions` array in the `projectionEngine.ts` module. This sorting ensures that, during a financial drawdown phase, the system correctly prioritizes liquidating uncrystallised 'DC Pension' pots (triggering the 4x tax-free partial crystallisation sequence) before falling back to the crystallised 'DC Pension (Post-Drawdown)' pots, resolving the bug requested by the user.

---
*PR created automatically by Jules for task [8258714923083676121](https://jules.google.com/task/8258714923083676121) started by @John-Bell*