### PR TITLE
Shallow copy budget list before sort on transactions page

### DIFF
--- a/src/pages/TransactionsPage.tsx
+++ b/src/pages/TransactionsPage.tsx
@@ -118,7 +118,7 @@ export function TransactionsPage() {
                                 className="w-full bg-white dark:bg-slate-800 border border-slate-200 dark:border-slate-700 rounded-xl px-4 py-3 text-slate-900 dark:text-white focus:outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary transition-colors appearance-none font-semibold shadow-sm"
                             >
                                 <option value="">All Budgets</option>
-                                {availableBudgets
+                                {[...availableBudgets]
                                     .sort((a, b) => a.name.localeCompare(b.name))
                                     .map(budget => (
                                         <option key={budget.id} value={budget.id}>


### PR DESCRIPTION
This PR fixes an array mutation bug on the transactions page, where `availableBudgets` was sorted in place, mutating the underlying state array. We now shallow copy the array using the spread operator before calling `.sort()` to ensure state immutability.

Fixes #305

---
*PR created automatically by Jules for task [5347929438692462425](https://jules.google.com/task/5347929438692462425) started by @John-Bell*